### PR TITLE
Change expanded actions from an unordered list to an ordered list

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,7 @@ export function formatComment(
     ? `\n\n**⚠️ Redundant actions detected:**\nThe following explicit actions are already covered by the wildcard pattern(s) above:\n${redundantActions.map((a) => `- \`${a}\``).join('\n')}`
     : '';
 
-  const actionsList = expandedActions.map((a) => `- ${formatActionWithLink(a)}`).join('\n');
+  const actionsList = expandedActions.map((a) => `1. ${formatActionWithLink(a)}`).join('\n');
 
   const actionsBlock = expandedActions.length > collapseThreshold
     ? `<details>


### PR DESCRIPTION
I think it would be helpful to refer to these in a numbered list?
<img width="700" height="664" alt="CleanShot 2025-12-13 at 11 52 33@2x" src="https://github.com/user-attachments/assets/6cd4ef2d-636e-4a0b-b244-84e585c8502f" />


