### PR TITLE
Run unit tests on pushes to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/update-iam-data.yml
+++ b/.github/workflows/update-iam-data.yml
@@ -13,11 +13,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Need full history for tags
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expand-iam-wildcards-action",
   "version": "1.0.0",
+  "packageManager": "npm@10.8.0",
   "description": "GitHub Action to expand IAM wildcard actions in PR comments",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Upgrade github actions to latest
add `packageManager` to `package.json` should level up caching without additonal config see: https://github.com/actions/setup-node/pull/1348