### PR TITLE
Exclude types.ts from unit test coverage, it has type-only defs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
       reportsDirectory: './coverage',
       provider: 'v8',
       include: ['src/**/*.ts'],
-      exclude: ['src/index.ts', 'src/**/*.test.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/index.ts',
+        'src/types.ts',
+      ],
     },
   },
 });


### PR DESCRIPTION
[`src/types.ts`](./src/types.ts) only contains TypeScript interfaces and has no runtime logic, so it always shows up as uncovered. TypeScript types are removed at compile time, they cannot be tested.

Coverage is kinda dumb... but including this in coverage is really dumb.