### PR TITLE
refactor: extract logic from index.ts to action.ts

### DIFF
--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -185,6 +185,18 @@ describe('processFiles', () => {
     expect(result.stats.wildcardsFound).toBe(0);
   });
 
+  it('returns empty result when wildcards found but none expand', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf', patch: makePatch(['"unknownservice:Get*"']) },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.comments).toEqual([]);
+    expect(result.stats.wildcardsFound).toBe(1);
+    expect(result.stats.actionsExpanded).toBe(0);
+  });
+
   it('processes files with wildcards and creates comments', () => {
     const files: PullRequestFile[] = [
       { filename: 'policy.tf', patch: makePatch(['"s3:Get*"']) },

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -19,9 +19,8 @@ describe('expandWildcards', () => {
     const result = expandWildcards(['s3:Get*']);
     expect(result.size).toBeGreaterThan(0);
     expect(result.has('s3:Get*')).toBe(true);
-    const expanded = result.get('s3:Get*');
-    expect(expanded).toBeDefined();
-    expect(expanded!.length).toBeGreaterThan(1);
+    const expanded = result.get('s3:Get*') ?? [];
+    expect(expanded.length).toBeGreaterThan(1);
   });
 
   it('does not include actions that do not expand', () => {

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+  COMMENT_MARKER,
+  expandWildcards,
+  findRedundantActions,
+  createReviewComments,
+  processFiles,
+} from './action.js';
+import type { PullRequestFile, WildcardBlock } from './types.js';
+
+describe('COMMENT_MARKER', () => {
+  it('contains the expected marker text', () => {
+    expect(COMMENT_MARKER).toBe('**IAM Wildcard Expansion**');
+  });
+});
+
+describe('expandWildcards', () => {
+  it('expands valid wildcard actions', () => {
+    const result = expandWildcards(['s3:Get*']);
+    expect(result.size).toBeGreaterThan(0);
+    expect(result.has('s3:Get*')).toBe(true);
+    const expanded = result.get('s3:Get*');
+    expect(expanded).toBeDefined();
+    expect(expanded!.length).toBeGreaterThan(1);
+  });
+
+  it('does not include actions that do not expand', () => {
+    const result = expandWildcards(['s3:GetObject']);
+    expect(result.has('s3:GetObject')).toBe(false);
+  });
+
+  it('handles unknown service prefixes gracefully', () => {
+    const result = expandWildcards(['unknownservice:*']);
+    expect(result.has('unknownservice:*')).toBe(false);
+  });
+
+  it('expands multiple wildcards', () => {
+    const result = expandWildcards(['s3:Get*', 'ec2:Describe*']);
+    expect(result.size).toBe(2);
+    expect(result.has('s3:Get*')).toBe(true);
+    expect(result.has('ec2:Describe*')).toBe(true);
+  });
+});
+
+describe('findRedundantActions', () => {
+  it('finds explicit actions covered by wildcards', () => {
+    const expanded = new Map([
+      ['s3:Get*', ['s3:getobject', 's3:getbucket']],
+    ]);
+    const result = findRedundantActions(['s3:GetObject', 's3:PutObject'], expanded);
+    expect(result).toEqual(['s3:GetObject']);
+  });
+
+  it('is case-insensitive', () => {
+    const expanded = new Map([
+      ['s3:Get*', ['s3:getobject']],
+    ]);
+    const result = findRedundantActions(['S3:GETOBJECT'], expanded);
+    expect(result).toEqual(['S3:GETOBJECT']);
+  });
+
+  it('returns empty array when no redundant actions', () => {
+    const expanded = new Map([
+      ['s3:Get*', ['s3:getobject']],
+    ]);
+    const result = findRedundantActions(['s3:PutObject'], expanded);
+    expect(result).toEqual([]);
+  });
+
+  it('handles empty inputs', () => {
+    expect(findRedundantActions([], new Map())).toEqual([]);
+    expect(findRedundantActions(['s3:GetObject'], new Map())).toEqual([]);
+  });
+});
+
+describe('createReviewComments', () => {
+  it('creates comments for blocks with expanded actions', () => {
+    const blocks: WildcardBlock[] = [{
+      file: 'policy.json',
+      startLine: 10,
+      endLine: 10,
+      actions: ['s3:Get*'],
+    }];
+    const expanded = new Map([
+      ['s3:Get*', ['s3:getobject', 's3:getbucket']],
+    ]);
+
+    const result = createReviewComments(blocks, expanded, [], 5);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('policy.json');
+    expect(result[0].line).toBe(10);
+    expect(result[0].body).toContain(COMMENT_MARKER);
+  });
+
+  it('skips blocks with no expanded actions', () => {
+    const blocks: WildcardBlock[] = [{
+      file: 'policy.json',
+      startLine: 10,
+      endLine: 10,
+      actions: ['unknown:Action*'],
+    }];
+    const expanded = new Map<string, string[]>();
+
+    const result = createReviewComments(blocks, expanded, [], 5);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('deduplicates and sorts expanded actions', () => {
+    const blocks: WildcardBlock[] = [{
+      file: 'policy.json',
+      startLine: 10,
+      endLine: 11,
+      actions: ['s3:Get*', 's3:GetB*'],
+    }];
+    const expanded = new Map([
+      ['s3:Get*', ['s3:getobject', 's3:getbucket']],
+      ['s3:GetB*', ['s3:getbucket', 's3:getbucketacl']],
+    ]);
+
+    const result = createReviewComments(blocks, expanded, [], 10);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].body).toContain('s3:getbucket');
+    expect(result[0].body).toContain('s3:getbucketacl');
+    expect(result[0].body).toContain('s3:getobject');
+  });
+
+  it('passes redundant actions to formatComment', () => {
+    const blocks: WildcardBlock[] = [{
+      file: 'policy.json',
+      startLine: 10,
+      endLine: 10,
+      actions: ['s3:Get*'],
+    }];
+    const expanded = new Map([
+      ['s3:Get*', ['s3:getobject']],
+    ]);
+
+    const result = createReviewComments(blocks, expanded, ['s3:GetObject'], 5);
+
+    expect(result[0].body).toContain('Redundant');
+  });
+
+  it('respects collapse threshold', () => {
+    const blocks: WildcardBlock[] = [{
+      file: 'policy.json',
+      startLine: 10,
+      endLine: 10,
+      actions: ['s3:*'],
+    }];
+    const manyActions = Array.from({ length: 20 }, (_, i) => `s3:action${i}`);
+    const expanded = new Map([['s3:*', manyActions]]);
+
+    const result = createReviewComments(blocks, expanded, [], 5);
+
+    expect(result[0].body).toContain('<details>');
+  });
+});
+
+describe('processFiles', () => {
+  const makePatch = (lines: string[]) =>
+    lines.map((line, i) => `@@ -0,0 +${i + 1} @@\n+${line}`).join('\n');
+
+  it('returns empty result for no matching files', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'README.md', patch: '+some content' },
+    ];
+
+    const result = processFiles(files, ['**/*.tf'], 5);
+
+    expect(result.comments).toEqual([]);
+    expect(result.stats.filesScanned).toBe(0);
+  });
+
+  it('returns empty result for files with no wildcards', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf', patch: makePatch(['"s3:GetObject"']) },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.comments).toEqual([]);
+    expect(result.stats.filesScanned).toBe(1);
+    expect(result.stats.wildcardsFound).toBe(0);
+  });
+
+  it('processes files with wildcards and creates comments', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf', patch: makePatch(['"s3:Get*"']) },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.comments.length).toBeGreaterThan(0);
+    expect(result.stats.wildcardsFound).toBe(1);
+    expect(result.stats.actionsExpanded).toBe(1);
+  });
+
+  it('filters files by patterns', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf', patch: makePatch(['"s3:Get*"']) },
+      { filename: 'policy.json', patch: makePatch(['"s3:Put*"']) },
+    ];
+
+    const result = processFiles(files, ['**/*.tf'], 5);
+
+    expect(result.stats.filesScanned).toBe(1);
+  });
+
+  it('detects redundant actions', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf', patch: makePatch(['"s3:Get*"', '"s3:GetObject"']) },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.redundantActions.length).toBeGreaterThan(0);
+  });
+
+  it('scans all files when no patterns provided', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'a.tf', patch: makePatch(['"s3:Get*"']) },
+      { filename: 'b.json', patch: makePatch(['"ec2:Describe*"']) },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.stats.filesScanned).toBe(2);
+  });
+
+  it('handles files without patches', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf' },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.comments).toEqual([]);
+    expect(result.stats.filesScanned).toBe(1);
+  });
+});

--- a/src/action.ts
+++ b/src/action.ts
@@ -12,7 +12,7 @@ export function expandWildcards(actions: readonly string[]): Map<string, string[
   for (const action of actions) {
     const result = expandIamAction(action);
     const isValidExpansion = result.length > 1 ||
-      (result.length === 1 && result[0].toLowerCase() !== action.toLowerCase());
+      (result.length === 1 && result[0]?.toLowerCase() !== action.toLowerCase());
 
     if (isValidExpansion) {
       expanded.set(action, result);

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,0 +1,145 @@
+import type { PullRequestFile, ReviewComment, WildcardBlock } from './types.js';
+import { extractFromDiff } from './diff.js';
+import { groupIntoConsecutiveBlocks, formatComment, type FormatOptions } from './utils.js';
+import { expandIamAction } from './expand.js';
+import { matchesPatterns } from './patterns.js';
+
+export const COMMENT_MARKER = '**IAM Wildcard Expansion**';
+
+export function expandWildcards(actions: readonly string[]): Map<string, string[]> {
+  const expanded = new Map<string, string[]>();
+
+  for (const action of actions) {
+    const result = expandIamAction(action);
+    const isValidExpansion = result.length > 1 ||
+      (result.length === 1 && result[0].toLowerCase() !== action.toLowerCase());
+
+    if (isValidExpansion) {
+      expanded.set(action, result);
+    }
+  }
+
+  return expanded;
+}
+
+export function findRedundantActions(
+  explicitActions: readonly string[],
+  expandedActions: Map<string, string[]>,
+): string[] {
+  const allExpanded = new Set<string>();
+  for (const actions of expandedActions.values()) {
+    for (const action of actions) {
+      allExpanded.add(action.toLowerCase());
+    }
+  }
+
+  return explicitActions.filter((action) =>
+    allExpanded.has(action.toLowerCase())
+  );
+}
+
+export function createReviewComments(
+  blocks: readonly WildcardBlock[],
+  expandedActions: Map<string, string[]>,
+  redundantActions: readonly string[],
+  collapseThreshold: number,
+): ReviewComment[] {
+  return blocks.flatMap((block) => {
+    const originalActions: string[] = [];
+    const allExpanded: string[] = [];
+
+    for (const action of block.actions) {
+      const expanded = expandedActions.get(action);
+      if (expanded) {
+        originalActions.push(action);
+        allExpanded.push(...expanded);
+      }
+    }
+
+    if (allExpanded.length === 0) return [];
+
+    const uniqueExpanded = [...new Set(allExpanded)].toSorted((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase())
+    );
+
+    const options: FormatOptions = { collapseThreshold, redundantActions };
+
+    return {
+      path: block.file,
+      line: block.endLine,
+      body: formatComment(originalActions, uniqueExpanded, options),
+    };
+  });
+}
+
+export interface ProcessingStats {
+  readonly filesScanned: number;
+  readonly wildcardsFound: number;
+  readonly blocksCreated: number;
+  readonly actionsExpanded: number;
+}
+
+export interface ProcessingResult {
+  readonly comments: ReviewComment[];
+  readonly redundantActions: string[];
+  readonly stats: ProcessingStats;
+}
+
+export function processFiles(
+  files: readonly PullRequestFile[],
+  filePatterns: readonly string[],
+  collapseThreshold: number,
+): ProcessingResult {
+  const filteredFiles = filePatterns.length > 0
+    ? files.filter((f) => matchesPatterns(f.filename, filePatterns))
+    : files;
+
+  if (filteredFiles.length === 0) {
+    return {
+      comments: [],
+      redundantActions: [],
+      stats: { filesScanned: 0, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+    };
+  }
+
+  const { wildcardMatches, explicitActions } = extractFromDiff(filteredFiles);
+
+  if (wildcardMatches.length === 0) {
+    return {
+      comments: [],
+      redundantActions: [],
+      stats: { filesScanned: filteredFiles.length, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+    };
+  }
+
+  const blocks = groupIntoConsecutiveBlocks(wildcardMatches);
+  const uniqueActions = [...new Set(wildcardMatches.map((m) => m.action))];
+  const expandedActions = expandWildcards(uniqueActions);
+
+  if (expandedActions.size === 0) {
+    return {
+      comments: [],
+      redundantActions: [],
+      stats: {
+        filesScanned: filteredFiles.length,
+        wildcardsFound: wildcardMatches.length,
+        blocksCreated: blocks.length,
+        actionsExpanded: 0,
+      },
+    };
+  }
+
+  const redundantActions = findRedundantActions(explicitActions, expandedActions);
+  const comments = createReviewComments(blocks, expandedActions, redundantActions, collapseThreshold);
+
+  return {
+    comments,
+    redundantActions,
+    stats: {
+      filesScanned: filteredFiles.length,
+      wildcardsFound: wildcardMatches.length,
+      blocksCreated: blocks.length,
+      actionsExpanded: expandedActions.size,
+    },
+  };
+}

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,10 +1,5 @@
-import type { WildcardMatch } from './types.js';
+import type { PullRequestFile, WildcardMatch } from './types.js';
 import { findPotentialWildcardActions, findExplicitActions } from './utils.js';
-
-interface PatchedFile {
-  readonly filename: string;
-  readonly patch?: string;
-}
 
 export interface DiffResults {
   readonly wildcardMatches: WildcardMatch[];
@@ -16,7 +11,7 @@ export function parseHunkHeader(line: string): number | null {
   return match?.[1] ? parseInt(match[1], 10) : null;
 }
 
-export function extractFromDiff(files: readonly PatchedFile[]): DiffResults {
+export function extractFromDiff(files: readonly PullRequestFile[]): DiffResults {
   const wildcardMatches: WildcardMatch[] = [];
   const explicitActions: string[] = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,79 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import type { ReviewComment, WildcardBlock } from './types.js';
-import { extractFromDiff } from './diff.js';
-import { groupIntoConsecutiveBlocks, formatComment, type FormatOptions } from './utils.js';
-import { expandIamAction } from './expand.js';
-import { matchesPatterns } from './patterns.js';
-
-const COMMENT_MARKER = '**IAM Wildcard Expansion**';
-
-function expandWildcards(actions: readonly string[]): Map<string, string[]> {
-  const expanded = new Map<string, string[]>();
-
-  for (const action of actions) {
-    const result = expandIamAction(action);
-    const isValidExpansion = result.length > 1 || (result.length === 1 && result[0] !== action);
-
-    if (isValidExpansion) {
-      expanded.set(action, result);
-      core.info(`Expanded ${action} to ${result.length} actions`);
-    }
-  }
-
-  return expanded;
-}
-
-function findRedundantActions(
-  explicitActions: readonly string[],
-  expandedActions: Map<string, string[]>,
-): string[] {
-  const allExpanded = new Set<string>();
-  for (const actions of expandedActions.values()) {
-    for (const action of actions) {
-      allExpanded.add(action.toLowerCase());
-    }
-  }
-
-  return explicitActions.filter((action) =>
-    allExpanded.has(action.toLowerCase())
-  );
-}
-
-function createReviewComments(
-  blocks: readonly WildcardBlock[],
-  expandedActions: Map<string, string[]>,
-  redundantActions: readonly string[],
-  collapseThreshold: number,
-): ReviewComment[] {
-  return blocks.flatMap((block) => {
-    const originalActions: string[] = [];
-    const allExpanded: string[] = [];
-
-    for (const action of block.actions) {
-      const expanded = expandedActions.get(action);
-      if (expanded) {
-        originalActions.push(action);
-        allExpanded.push(...expanded);
-      }
-    }
-
-    if (allExpanded.length === 0) return [];
-
-    const uniqueExpanded = [...new Set(allExpanded)].toSorted((a, b) =>
-      a.toLowerCase().localeCompare(b.toLowerCase())
-    );
-
-    const options: FormatOptions = { collapseThreshold, redundantActions };
-
-    return {
-      path: block.file,
-      line: block.endLine,
-      body: formatComment(originalActions, uniqueExpanded, options),
-    };
-  });
-}
+import { processFiles, COMMENT_MARKER } from './action.js';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -123,56 +51,42 @@ async function run(): Promise<void> {
 
     core.info(`Analyzing PR #${pullNumber} in ${owner}/${repo}`);
 
-    // Delete existing comments from previous runs
     const deletedCount = await deleteExistingComments(octokit, owner, repo, pullNumber);
     if (deletedCount > 0) {
       core.info(`Deleted ${deletedCount} existing comment(s) from previous runs`);
     }
 
-    const { data: allFiles } = await octokit.rest.pulls.listFiles({
+    const { data: files } = await octokit.rest.pulls.listFiles({
       owner,
       repo,
       pull_number: pullNumber,
     });
 
-    const files = filePatterns.length > 0
-      ? allFiles.filter((f) => matchesPatterns(f.filename, filePatterns))
-      : allFiles;
+    const { comments, redundantActions, stats } = processFiles(files, filePatterns, collapseThreshold);
 
-    if (files.length === 0) {
+    if (stats.filesScanned === 0) {
       core.info('No files matched the configured patterns.');
       return;
     }
 
-    core.info(`Scanning ${files.length} file(s) matching patterns`);
+    core.info(`Scanned ${stats.filesScanned} file(s)`);
 
-    const { wildcardMatches, explicitActions } = extractFromDiff(files);
-    if (wildcardMatches.length === 0) {
+    if (stats.wildcardsFound === 0) {
       core.info('No IAM wildcard actions found in the changes.');
       return;
     }
 
-    core.info(`Found ${wildcardMatches.length} IAM wildcard action(s)`);
-    if (explicitActions.length > 0) {
-      core.info(`Found ${explicitActions.length} explicit action(s)`);
-    }
+    core.info(`Found ${stats.wildcardsFound} wildcard(s), grouped into ${stats.blocksCreated} block(s)`);
 
-    const blocks = groupIntoConsecutiveBlocks(wildcardMatches);
-    core.info(`Grouped into ${blocks.length} block(s)`);
-
-    const uniqueActions = [...new Set(wildcardMatches.map((m) => m.action))];
-    const expandedActions = expandWildcards(uniqueActions);
-    if (expandedActions.size === 0) {
+    if (stats.actionsExpanded === 0) {
       core.info('No wildcard actions could be expanded.');
       return;
     }
 
-    const redundantActions = findRedundantActions(explicitActions, expandedActions);
     if (redundantActions.length > 0) {
       core.warning(`Found ${redundantActions.length} redundant action(s): ${redundantActions.join(', ')}`);
     }
 
-    const comments = createReviewComments(blocks, expandedActions, redundantActions, collapseThreshold);
     if (comments.length === 0) {
       core.info('No comments to post.');
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,3 +16,8 @@ export interface ReviewComment {
   readonly line: number;
   readonly body: string;
 }
+
+export interface PullRequestFile {
+  readonly filename: string;
+  readonly patch?: string;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: [
         'src/**/*.test.ts',
+        'src/iam-actions.ts',
         'src/index.ts',
         'src/types.ts',
       ],


### PR DESCRIPTION
I had a bunch of junk where it should have been, that would have been hard to test.

- Move expandWildcards, findRedundantActions, createReviewComments, processFiles to new action.ts module
- index.ts now contains only I/O (inputs, GitHub API, logging)
- Add test s for action.ts
- Fix case-sensitivity bug in expandWildcards comparison
- exclude generated iam-actions.ts from code coverage