### PR TITLE
Update documentation for PascalCase S3 permission names with links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ npm run typecheck
 
 # Lint
 npm run lint
+npm run lint:md
 
 # Build
 npm run build
@@ -25,7 +26,7 @@ npm run build
 
 1. Fork the repo and create a branch from `main`
 2. Make your changes
-3. Run `npm test` and `npm run lint`
+3. Run `npm test`, `npm run lint`, and `npm run lint:md`
 4. Run `npm run build` and commit the updated `dist/index.js` (this will help us actually run it as an action if we wish)
 5. Open a PR. Be verbose. We like to read.
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ The action posts an inline comment:
 
 > **IAM Wildcard Expansion**
 >
-> `s3:Get*Tagging` expands to 5 action(s):
+> `s3:Get*Tagging` expands to 5
+> [`s3`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html) actions:
 >
-> 1. [`s3:getbuckettagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html)
-> 2. [`s3:getjobtagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html)
-> 3. [`s3:getobjecttagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html)
-> 4. [`s3:getobjectversiontagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html)
-> 5. [`s3:getstoragelensconfigurationtagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html)
+> 1. [`s3:GetBucketTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
+> 2. [`s3:GetJobTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetJobTagging.html)
+> 3. [`s3:GetObjectTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html)
+> 4. [`s3:GetObjectVersionTagging`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/setting-repl-config-perm-overview.html)
+> 5. [`s3:GetStorageLensConfigurationTagging`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetStorageLensConfigurationTagging.html)
 
 Consecutive wildcards are grouped into a single comment. Expanded actions link to AWS documentation.
 


### PR DESCRIPTION
Since each of the pages has an official link from the main s3 site, I thought it would be helpful to link the to main s3 documentation along with the individual docs instead of having the same link pasted 5 times.

An alternative was to not add links for each of the expanded permissions and leave them as a list only.