### PR TITLE
Add reference links for versions in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add initial release
+
+[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.8...HEAD
+[1.1.8]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.7...v1.1.8
+[1.1.7]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.6...v1.1.7
+[1.1.6]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.5...v1.1.6
+[1.1.5]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.4...v1.1.5
+[1.1.4]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.3...v1.1.4
+[1.1.3]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/thekbb/expand-aws-iam-wildcards/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add initial release
 
+<!-- markdownlint-disable-next-line MD053 -->
 [Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.8...HEAD
 [1.1.8]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.7...v1.1.8
 [1.1.7]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.1.6...v1.1.7


### PR DESCRIPTION
I didn't read https://keepachangelog.com/en/1.1.0/ closely enough
<img height="200" alt="CleanShot 2026-01-31 at 23 00 02@2x" src="https://github.com/user-attachments/assets/60ccfccf-139c-4890-9a75-9cb2e05c7658" />
The versions are supposed to be links to the diff. 