### PR TITLE
Extract per-patch parsing in diff processing.

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -6,41 +6,50 @@ export interface DiffResults {
   readonly explicitActions: string[];
 }
 
+function extractFromPatch(patch: string, filename: string): DiffResults {
+  const wildcardMatches: WildcardMatch[] = [];
+  const explicitActions: string[] = [];
+  let currentLine = 0;
+
+  for (const line of patch.split('\n')) {
+    const hunkStart = parseHunkHeader(line);
+    if (hunkStart !== null) {
+      currentLine = hunkStart - 1;
+      continue;
+    }
+
+    if (line.startsWith('-')) continue;
+
+    currentLine++;
+
+    if (line.startsWith('+')) {
+      for (const action of findPotentialWildcardActions(line)) {
+        wildcardMatches.push({ action, line: currentLine, file: filename });
+      }
+      for (const action of findExplicitActions(line)) {
+        explicitActions.push(action);
+      }
+    }
+  }
+
+  return { wildcardMatches, explicitActions };
+}
+
 export function parseHunkHeader(line: string): number | null {
   const match = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
   return match?.[1] ? parseInt(match[1], 10) : null;
 }
 
 export function extractFromDiff(files: readonly PullRequestFile[]): DiffResults {
-  const wildcardMatches: WildcardMatch[] = [];
-  const explicitActions: string[] = [];
-
-  for (const file of files) {
-    if (!file.patch) continue;
-
-    let currentLine = 0;
-
-    for (const line of file.patch.split('\n')) {
-      const hunkStart = parseHunkHeader(line);
-      if (hunkStart !== null) {
-        currentLine = hunkStart - 1;
-        continue;
-      }
-
-      if (line.startsWith('-')) continue;
-
-      currentLine++;
-
-      if (line.startsWith('+')) {
-        for (const action of findPotentialWildcardActions(line)) {
-          wildcardMatches.push({ action, line: currentLine, file: file.filename });
-        }
-        for (const action of findExplicitActions(line)) {
-          explicitActions.push(action);
-        }
-      }
-    }
-  }
-
-  return { wildcardMatches, explicitActions };
+  return files
+    .filter((file) => file.patch)
+    .map((file) => extractFromPatch(file.patch!, file.filename))
+    .reduce<DiffResults>(
+      (acc, result) => {
+        acc.wildcardMatches.push(...result.wildcardMatches);
+        acc.explicitActions.push(...result.explicitActions);
+        return acc;
+      },
+      { wildcardMatches: [], explicitActions: [] },
+    );
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -42,8 +42,8 @@ export function parseHunkHeader(line: string): number | null {
 
 export function extractFromDiff(files: readonly PullRequestFile[]): DiffResults {
   return files
-    .filter((file) => file.patch)
-    .map((file) => extractFromPatch(file.patch!, file.filename))
+    .filter((file): file is PullRequestFile & { patch: string } => typeof file.patch === 'string')
+    .map((file) => extractFromPatch(file.patch, file.filename))
     .reduce<DiffResults>(
       (acc, result) => {
         acc.wildcardMatches.push(...result.wildcardMatches);


### PR DESCRIPTION
MOve logic that reads a per-file diff from the PR's patch to a helper `extractFromPatch` so the stateful line-tracking work is all together.

`extractFromDiff` just filters files with a ptach, calls the helper and combines the results.

I think it reads better.