### PR TITLE
paginate pull request file retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Paginate pull request file retrieval so large PRs are scanned completely
+
 ## [1.1.10] = 2026-3-21
 
 ### Changed

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { listPullRequestFiles } from './github.js';
+import type { PullRequestFile } from './types.js';
+
+describe('listPullRequestFiles', () => {
+  it('paginates pull request files with a page size of 100', async () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy-1.tf', patch: '+ "s3:Get*"' },
+      { filename: 'policy-2.tf', patch: '+ "ec2:Describe*"' },
+    ];
+    const listFiles = {};
+    const paginate = vi.fn().mockResolvedValue(files);
+    const octokit = {
+      paginate,
+      rest: {
+        pulls: {
+          listFiles,
+        },
+      },
+    };
+
+    const result = await listPullRequestFiles(octokit, 'thekbb', 'expand-aws-iam-wildcards', 42);
+
+    expect(result).toEqual(files);
+    expect(paginate).toHaveBeenCalledWith(listFiles, {
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      pull_number: 42,
+      per_page: 100,
+    });
+  });
+});

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,32 @@
+import type { PullRequestFile } from './types.js';
+
+interface PullRequestFilesClient {
+  readonly paginate: (
+    route: unknown,
+    parameters: {
+      owner: string;
+      repo: string;
+      pull_number: number;
+      per_page: number;
+    },
+  ) => Promise<PullRequestFile[]>;
+  readonly rest: {
+    readonly pulls: {
+      readonly listFiles: unknown;
+    };
+  };
+}
+
+export async function listPullRequestFiles(
+  octokit: PullRequestFilesClient,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+): Promise<PullRequestFile[]> {
+  return octokit.paginate(octokit.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 import { processFiles, COMMENT_MARKER } from './action.js';
+import { listPullRequestFiles } from './github.js';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -56,11 +57,7 @@ async function run(): Promise<void> {
       core.info(`Deleted ${deletedCount} existing comment(s) from previous runs`);
     }
 
-    const { data: files } = await octokit.rest.pulls.listFiles({
-      owner,
-      repo,
-      pull_number: pullNumber,
-    });
+    const files = await listPullRequestFiles(octokit, owner, repo, pullNumber);
 
     const { comments, redundantActions, stats } = processFiles(files, filePatterns, collapseThreshold);
 


### PR DESCRIPTION
Large pull requests were only having the first page of changed files scanned because the action called `pulls.listFiles` once instead of paginating through the full result set.

Large PRs would may have had some wildcards not expanded, a silent failure.

This change fixes that by switching PR file retrieval to [`octokit.paginate(...)`](https://github.com/octokit/octokit.js/?tab=readme-ov-file#pagination) with `per_page: 100`