### PR TITLE
Truncate comments that are too large for GitHub, and link to workflow logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Paginate pull request file retrieval so large PRs are scanned completely
+- Truncate oversized review comments that would break GitHub, and link full IAM expansions from the PR comment to the
+  workflow run logs
 
 ## [1.1.10] = 2026-3-21
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       - uses: thekbb/expand-aws-iam-wildcards@v1
 ```
 
-That's it. When a PR adds `s3:Get*`, reviewers see an inline comment listing every matching action with links to AWS documentation.
+That's it. When a PR adds `s3:Get*`, reviewers see an inline comment listing the matching actions with links to AWS documentation.
 
 ## What It Does
 
@@ -52,6 +52,8 @@ The action posts an inline comment:
 > 5. [`s3:GetStorageLensConfigurationTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html)
 
 Consecutive wildcards are grouped into a single comment. Expanded actions link to AWS documentation.
+Very large expansions are truncated in the PR comment to stay within GitHub comment limits,
+and the full list is written to the workflow run logs.
 
 ## Inputs
 

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -156,6 +156,32 @@ describe('createReviewComments', () => {
 
     expect(result[0].body).toContain('<details>');
   });
+
+  it('truncates oversized comment bodies and links to workflow logs', () => {
+    const blocks: WildcardBlock[] = [{
+      file: 'policy.json',
+      startLine: 10,
+      endLine: 10,
+      actions: ['s3:*'],
+    }];
+    const manyActions = Array.from({ length: 20 }, (_, i) => `unknown:Action${i}`);
+    const expanded = new Map([['s3:*', manyActions]]);
+
+    const result = createReviewComments(
+      blocks,
+      expanded,
+      [],
+      5,
+      {
+        maxCommentBodyLength: 325,
+        truncationUrl: 'https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123',
+      },
+    );
+
+    expect(result[0].body).toContain('workflow run logs');
+    expect(result[0].body).toContain('Showing first');
+    expect(result[0].body).not.toContain('unknown:Action19');
+  });
 });
 
 describe('processFiles', () => {
@@ -195,6 +221,7 @@ describe('processFiles', () => {
     expect(result.comments).toEqual([]);
     expect(result.stats.wildcardsFound).toBe(1);
     expect(result.stats.actionsExpanded).toBe(0);
+    expect(result.truncatedComments).toEqual([]);
   });
 
   it('processes files with wildcards and creates comments', () => {
@@ -250,5 +277,26 @@ describe('processFiles', () => {
 
     expect(result.comments).toEqual([]);
     expect(result.stats.filesScanned).toBe(1);
+  });
+
+  it('returns truncated comment metadata when a comment body is trimmed', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf', patch: makePatch(['"s3:*"']) },
+    ];
+
+    const result = processFiles(
+      files,
+      [],
+      5,
+      {
+        maxCommentBodyLength: 325,
+        truncationUrl: 'https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123',
+      },
+    );
+
+    expect(result.comments).toHaveLength(1);
+    expect(result.truncatedComments).toHaveLength(1);
+    expect(result.truncatedComments[0].file).toBe('policy.tf');
+    expect(result.comments[0].body).toContain('workflow run logs');
   });
 });

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,10 +1,28 @@
 import type { PullRequestFile, ReviewComment, WildcardBlock } from './types.js';
 import { extractFromDiff } from './diff.js';
-import { groupIntoConsecutiveBlocks, formatComment, type FormatOptions } from './utils.js';
+import { groupIntoConsecutiveBlocks, formatCommentResult, type FormatOptions } from './utils.js';
 import { expandIamAction } from './expand.js';
 import { matchesPatterns } from './patterns.js';
 
 export const COMMENT_MARKER = '**IAM Wildcard Expansion**';
+
+export interface ReviewCommentOptions {
+  readonly truncationUrl?: string;
+  readonly maxCommentBodyLength?: number;
+}
+
+export interface TruncatedComment {
+  readonly file: string;
+  readonly line: number;
+  readonly originalActions: readonly string[];
+  readonly expandedActions: readonly string[];
+  readonly renderedActionsCount: number;
+}
+
+interface ReviewCommentsResult {
+  readonly comments: ReviewComment[];
+  readonly truncatedComments: TruncatedComment[];
+}
 
 export function expandWildcards(actions: readonly string[]): Map<string, string[]> {
   const expanded = new Map<string, string[]>();
@@ -38,13 +56,17 @@ export function findRedundantActions(
   );
 }
 
-export function createReviewComments(
+function buildReviewComments(
   blocks: readonly WildcardBlock[],
   expandedActions: Map<string, string[]>,
   redundantActions: readonly string[],
   collapseThreshold: number,
-): ReviewComment[] {
-  return blocks.flatMap((block) => {
+  options: ReviewCommentOptions = {},
+): ReviewCommentsResult {
+  const comments: ReviewComment[] = [];
+  const truncatedComments: TruncatedComment[] = [];
+
+  for (const block of blocks) {
     const originalActions: string[] = [];
     const allExpanded: string[] = [];
 
@@ -56,20 +78,50 @@ export function createReviewComments(
       }
     }
 
-    if (allExpanded.length === 0) return [];
+    if (allExpanded.length === 0) {
+      continue;
+    }
 
     const uniqueExpanded = [...new Set(allExpanded)].toSorted((a, b) =>
       a.toLowerCase().localeCompare(b.toLowerCase())
     );
 
-    const options: FormatOptions = { collapseThreshold, redundantActions };
+    const formatOptions: FormatOptions = {
+      collapseThreshold,
+      redundantActions,
+      truncationUrl: options.truncationUrl,
+      maxCommentBodyLength: options.maxCommentBodyLength,
+    };
+    const formattedComment = formatCommentResult(originalActions, uniqueExpanded, formatOptions);
 
-    return {
+    comments.push({
       path: block.file,
       line: block.endLine,
-      body: formatComment(originalActions, uniqueExpanded, options),
-    };
-  });
+      body: formattedComment.body,
+    });
+
+    if (formattedComment.truncated) {
+      truncatedComments.push({
+        file: block.file,
+        line: block.endLine,
+        originalActions,
+        expandedActions: uniqueExpanded,
+        renderedActionsCount: formattedComment.renderedActionsCount,
+      });
+    }
+  }
+
+  return { comments, truncatedComments };
+}
+
+export function createReviewComments(
+  blocks: readonly WildcardBlock[],
+  expandedActions: Map<string, string[]>,
+  redundantActions: readonly string[],
+  collapseThreshold: number,
+  options: ReviewCommentOptions = {},
+): ReviewComment[] {
+  return buildReviewComments(blocks, expandedActions, redundantActions, collapseThreshold, options).comments;
 }
 
 export interface ProcessingStats {
@@ -83,12 +135,14 @@ export interface ProcessingResult {
   readonly comments: ReviewComment[];
   readonly redundantActions: string[];
   readonly stats: ProcessingStats;
+  readonly truncatedComments: TruncatedComment[];
 }
 
 export function processFiles(
   files: readonly PullRequestFile[],
   filePatterns: readonly string[],
   collapseThreshold: number,
+  options: ReviewCommentOptions = {},
 ): ProcessingResult {
   const filteredFiles = filePatterns.length > 0
     ? files.filter((f) => matchesPatterns(f.filename, filePatterns))
@@ -99,6 +153,7 @@ export function processFiles(
       comments: [],
       redundantActions: [],
       stats: { filesScanned: 0, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+      truncatedComments: [],
     };
   }
 
@@ -109,6 +164,7 @@ export function processFiles(
       comments: [],
       redundantActions: [],
       stats: { filesScanned: filteredFiles.length, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+      truncatedComments: [],
     };
   }
 
@@ -126,14 +182,21 @@ export function processFiles(
         blocksCreated: blocks.length,
         actionsExpanded: 0,
       },
+      truncatedComments: [],
     };
   }
 
   const redundantActions = findRedundantActions(explicitActions, expandedActions);
-  const comments = createReviewComments(blocks, expandedActions, redundantActions, collapseThreshold);
+  const reviewComments = buildReviewComments(
+    blocks,
+    expandedActions,
+    redundantActions,
+    collapseThreshold,
+    options,
+  );
 
   return {
-    comments,
+    comments: reviewComments.comments,
     redundantActions,
     stats: {
       filesScanned: filteredFiles.length,
@@ -141,5 +204,6 @@ export function processFiles(
       blocksCreated: blocks.length,
       actionsExpanded: expandedActions.size,
     },
+    truncatedComments: reviewComments.truncatedComments,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,43 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { processFiles, COMMENT_MARKER } from './action.js';
+import { processFiles, COMMENT_MARKER, type TruncatedComment } from './action.js';
 import { listPullRequestFiles } from './github.js';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
+
+function getWorkflowRunUrl(owner: string, repo: string): string | undefined {
+  const runId = process.env.GITHUB_RUN_ID;
+  if (!runId) {
+    return undefined;
+  }
+
+  const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+  return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
+}
+
+function logTruncatedComments(
+  truncatedComments: readonly TruncatedComment[],
+  workflowRunUrl?: string,
+): void {
+  if (truncatedComments.length === 0) {
+    return;
+  }
+
+  const logLocation = workflowRunUrl ? ` Full lists are available in this workflow run: ${workflowRunUrl}` : '';
+  core.warning(
+    `Truncated ${truncatedComments.length} review comment(s) to stay within GitHub comment limits.${logLocation}`
+  );
+
+  for (const truncatedComment of truncatedComments) {
+    core.info([
+      `Full IAM expansion for ${truncatedComment.file}:${truncatedComment.line}`,
+      `Rendered ${truncatedComment.renderedActionsCount} of ${truncatedComment.expandedActions.length} action(s) in the PR comment.`,
+      `Wildcard patterns: ${truncatedComment.originalActions.join(', ')}`,
+      ...truncatedComment.expandedActions.map((action) => `- ${action}`),
+    ].join('\n'));
+  }
+}
 
 async function deleteExistingComments(
   octokit: Octokit,
@@ -49,6 +82,7 @@ async function run(): Promise<void> {
     const { owner, repo } = context.repo;
     const pullNumber = context.payload.pull_request.number as number;
     const commitSha = context.payload.pull_request.head.sha as string;
+    const workflowRunUrl = getWorkflowRunUrl(owner, repo);
 
     core.info(`Analyzing PR #${pullNumber} in ${owner}/${repo}`);
 
@@ -59,7 +93,12 @@ async function run(): Promise<void> {
 
     const files = await listPullRequestFiles(octokit, owner, repo, pullNumber);
 
-    const { comments, redundantActions, stats } = processFiles(files, filePatterns, collapseThreshold);
+    const { comments, redundantActions, stats, truncatedComments } = processFiles(
+      files,
+      filePatterns,
+      collapseThreshold,
+      { truncationUrl: workflowRunUrl },
+    );
 
     if (stats.filesScanned === 0) {
       core.info('No files matched the configured patterns.');
@@ -88,6 +127,8 @@ async function run(): Promise<void> {
       core.info('No comments to post.');
       return;
     }
+
+    logTruncatedComments(truncatedComments, workflowRunUrl);
 
     await octokit.rest.pulls.createReview({
       owner,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -290,6 +290,21 @@ describe('formatComment', () => {
     expect(result.body).toContain('Showing first');
   });
 
+  it('truncates oversized comments without adding a log link when no URL is available', () => {
+    const expanded = Array.from({ length: 20 }, (_, i) => `unknown:Action${i}`);
+    const result = formatCommentResult(
+      ['s3:*'],
+      expanded,
+      { maxCommentBodyLength: 325 },
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.renderedActionsCount).toBeGreaterThan(0);
+    expect(result.renderedActionsCount).toBeLessThan(expanded.length);
+    expect(result.body).toContain('Showing first');
+    expect(result.body).not.toContain('workflow run logs');
+  });
+
   it('falls back to a minimal comment when even the truncated list will not fit', () => {
     const expanded = Array.from({ length: 20 }, (_, i) => `unknown:Action${i}`);
     const result = formatCommentResult(
@@ -305,6 +320,20 @@ describe('formatComment', () => {
     expect(result.renderedActionsCount).toBe(0);
     expect(result.body).toContain('Expanded actions were omitted from this comment');
     expect(result.body).toContain('workflow run logs');
+  });
+
+  it('falls back to a minimal comment without a log link when no URL is available', () => {
+    const expanded = Array.from({ length: 20 }, (_, i) => `unknown:Action${i}`);
+    const result = formatCommentResult(
+      ['s3:*'],
+      expanded,
+      { maxCommentBodyLength: 10 },
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.renderedActionsCount).toBe(0);
+    expect(result.body).toContain('Expanded actions were omitted from this comment');
+    expect(result.body).not.toContain('workflow run logs');
   });
 
   it('shows redundant actions warning when provided', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -290,6 +290,23 @@ describe('formatComment', () => {
     expect(result.body).toContain('Showing first');
   });
 
+  it('falls back to a minimal comment when even the truncated list will not fit', () => {
+    const expanded = Array.from({ length: 20 }, (_, i) => `unknown:Action${i}`);
+    const result = formatCommentResult(
+      ['s3:*'],
+      expanded,
+      {
+        maxCommentBodyLength: 10,
+        truncationUrl: 'https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123',
+      },
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.renderedActionsCount).toBe(0);
+    expect(result.body).toContain('Expanded actions were omitted from this comment');
+    expect(result.body).toContain('workflow run logs');
+  });
+
   it('shows redundant actions warning when provided', () => {
     const result = formatComment(
       ['s3:Get*'],

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -4,6 +4,7 @@ import {
   findExplicitActions,
   groupIntoConsecutiveBlocks,
   formatComment,
+  formatCommentResult,
 } from './utils.js';
 import type { WildcardMatch } from './types.js';
 
@@ -269,6 +270,24 @@ describe('formatComment', () => {
     const result = formatComment(['s3:Get*'], expanded, { collapseThreshold: 2 });
 
     expect(result).toContain('<details>');
+  });
+
+  it('truncates oversized comments and links to workflow logs', () => {
+    const expanded = Array.from({ length: 20 }, (_, i) => `unknown:Action${i}`);
+    const result = formatCommentResult(
+      ['s3:*'],
+      expanded,
+      {
+        maxCommentBodyLength: 325,
+        truncationUrl: 'https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123',
+      },
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.renderedActionsCount).toBeGreaterThan(0);
+    expect(result.renderedActionsCount).toBeLessThan(expanded.length);
+    expect(result.body).toContain('workflow run logs');
+    expect(result.body).toContain('Showing first');
   });
 
   it('shows redundant actions warning when provided', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import { formatActionWithLink } from './docs.js';
 
 const IAM_WILDCARD_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]*\*[a-zA-Z0-9*?]*)["']?/g;
 const IAM_EXPLICIT_PATTERN = /["']([a-zA-Z0-9-]+:[a-zA-Z][a-zA-Z0-9]*)["']/g;
+export const MAX_COMMENT_BODY_LENGTH = 62_000;
 
 export function findPotentialWildcardActions(line: string): string[] {
   return [...line.matchAll(IAM_WILDCARD_PATTERN)]
@@ -58,18 +59,43 @@ export function groupIntoConsecutiveBlocks(matches: readonly WildcardMatch[]): W
 export interface FormatOptions {
   readonly collapseThreshold?: number;
   readonly redundantActions?: readonly string[];
+  readonly truncationUrl?: string;
+  readonly maxCommentBodyLength?: number;
 }
 
-export function formatComment(
+export interface FormattedComment {
+  readonly body: string;
+  readonly renderedActionsCount: number;
+  readonly truncated: boolean;
+}
+
+function createTruncationNotice(
+  renderedActionsCount: number,
+  totalActionsCount: number,
+  truncationUrl?: string,
+): string {
+  const logMessage = truncationUrl
+    ? ` The full expanded list is in the [workflow run logs](${truncationUrl}).`
+    : '';
+
+  if (renderedActionsCount === 0) {
+    return `\n\nThe expanded action list is omitted here to keep this review comment within GitHub limits.${logMessage}`;
+  }
+
+  return `\n\nShowing first ${renderedActionsCount} of ${totalActionsCount} expanded actions to keep this review comment within GitHub limits.${logMessage}`;
+}
+
+function buildCommentBody(
   originalActions: readonly string[],
-  expandedActions: readonly string[],
+  displayedActions: readonly string[],
+  totalExpandedActionsCount: number,
   options: FormatOptions = {},
 ): string {
-  const { collapseThreshold = 5, redundantActions } = options;
+  const { collapseThreshold = 5, redundantActions, truncationUrl } = options;
 
   const header = originalActions.length === 1
-    ? `\`${originalActions[0]}\` expands to ${expandedActions.length} action(s):`
-    : `${originalActions.length} wildcard patterns expand to ${expandedActions.length} action(s):`;
+    ? `\`${originalActions[0]}\` expands to ${totalExpandedActionsCount} action(s):`
+    : `${originalActions.length} wildcard patterns expand to ${totalExpandedActionsCount} action(s):`;
 
   const patterns = originalActions.length > 1
     ? `\n**Patterns:**\n${originalActions.map((a) => `- \`${a}\``).join('\n')}`
@@ -79,9 +105,15 @@ export function formatComment(
     ? `\n\n**⚠️ Redundant actions detected:**\nThe following explicit actions are already covered by the wildcard pattern(s) above:\n${redundantActions.map((a) => `- \`${a}\``).join('\n')}`
     : '';
 
-  const actionsList = expandedActions.map((a) => `1. ${formatActionWithLink(a)}`).join('\n');
+  const truncationNotice = displayedActions.length < totalExpandedActionsCount
+    ? createTruncationNotice(displayedActions.length, totalExpandedActionsCount, truncationUrl)
+    : '';
 
-  const actionsBlock = expandedActions.length > collapseThreshold
+  const actionsList = displayedActions.map((a) => `1. ${formatActionWithLink(a)}`).join('\n');
+
+  const actionsBlock = displayedActions.length === 0
+    ? '_Full expanded list omitted from this comment._'
+    : displayedActions.length > collapseThreshold
     ? `<details>
 <summary>Click to expand</summary>
 
@@ -92,7 +124,76 @@ ${actionsList}
 
   return `**IAM Wildcard Expansion**
 
-${header}${patterns}${warning}
+${header}${patterns}${warning}${truncationNotice}
 
 ${actionsBlock}`;
+}
+
+function createMinimalCommentBody(truncationUrl?: string): string {
+  const logMessage = truncationUrl
+    ? ` The full expanded list is in the [workflow run logs](${truncationUrl}).`
+    : '';
+
+  return `**IAM Wildcard Expansion**
+
+Expanded actions were omitted from this comment to stay within GitHub limits.${logMessage}`;
+}
+
+export function formatCommentResult(
+  originalActions: readonly string[],
+  expandedActions: readonly string[],
+  options: FormatOptions = {},
+): FormattedComment {
+  const { maxCommentBodyLength = MAX_COMMENT_BODY_LENGTH } = options;
+  const safeMaxCommentBodyLength = Math.max(1, maxCommentBodyLength);
+  const fullBody = buildCommentBody(originalActions, expandedActions, expandedActions.length, options);
+
+  if (fullBody.length <= safeMaxCommentBodyLength) {
+    return {
+      body: fullBody,
+      renderedActionsCount: expandedActions.length,
+      truncated: false,
+    };
+  }
+
+  let bestCount = 0;
+  let bestBody = '';
+  let low = 0;
+  let high = expandedActions.length;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidateBody = buildCommentBody(
+      originalActions,
+      expandedActions.slice(0, mid),
+      expandedActions.length,
+      options,
+    );
+
+    if (candidateBody.length <= safeMaxCommentBodyLength) {
+      bestCount = mid;
+      bestBody = candidateBody;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  if (bestBody === '') {
+    bestBody = createMinimalCommentBody(options.truncationUrl);
+  }
+
+  return {
+    body: bestBody,
+    renderedActionsCount: bestCount,
+    truncated: true,
+  };
+}
+
+export function formatComment(
+  originalActions: readonly string[],
+  expandedActions: readonly string[],
+  options: FormatOptions = {},
+): string {
+  return formatCommentResult(originalActions, expandedActions, options).body;
 }


### PR DESCRIPTION
GitHub has an upper limit on characters in a comment of `65,536`.
If someone puts in `ec:*` the resulting expansion is a comment far larger than what github allows.

We now write the whole list out to the action's build log, truncate the comment (when larger than `MAX_COMMENT_BODY_LENGTH <= 62_000`) with a link to said build log.

If folks are hitting this, they should pay my friend John (who is kind of a big deal around town) to teach them about the principle of least privilege.