### PR TITLE
Sync review comments in place when anchors are unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reuse existing review comments when the file and line anchor are unchanged, updating comment bodies in place when
+  needed to preserve discussion threads and reduce comment churn
+
 ### Fixed
 
 - Paginate pull request file retrieval so large PRs are scanned completely

--- a/dist/index.js
+++ b/dist/index.js
@@ -36020,6 +36020,7 @@ function formatActionWithLink(action) {
 
 const IAM_WILDCARD_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]*\*[a-zA-Z0-9*?]*)["']?/g;
 const IAM_EXPLICIT_PATTERN = /["']([a-zA-Z0-9-]+:[a-zA-Z][a-zA-Z0-9]*)["']/g;
+const MAX_COMMENT_BODY_LENGTH = 62_000;
 function findPotentialWildcardActions(line) {
     return [...line.matchAll(IAM_WILDCARD_PATTERN)]
         .map((match) => match[1]?.trim())
@@ -36063,31 +36064,92 @@ function groupIntoConsecutiveBlocks(matches) {
     blocks.push({ ...current, actions: [...current.actions] });
     return blocks;
 }
-function formatComment(originalActions, expandedActions, options = {}) {
-    const { collapseThreshold = 5, redundantActions } = options;
+function createTruncationNotice(renderedActionsCount, totalActionsCount, truncationUrl) {
+    const logMessage = truncationUrl
+        ? ` The full expanded list is in the [workflow run logs](${truncationUrl}).`
+        : '';
+    if (renderedActionsCount === 0) {
+        return `\n\nThe expanded action list is omitted here to keep this review comment within GitHub limits.${logMessage}`;
+    }
+    return `\n\nShowing first ${renderedActionsCount} of ${totalActionsCount} expanded actions to keep this review comment within GitHub limits.${logMessage}`;
+}
+function buildCommentBody(originalActions, displayedActions, totalExpandedActionsCount, options = {}) {
+    const { collapseThreshold = 5, redundantActions, truncationUrl } = options;
     const header = originalActions.length === 1
-        ? `\`${originalActions[0]}\` expands to ${expandedActions.length} action(s):`
-        : `${originalActions.length} wildcard patterns expand to ${expandedActions.length} action(s):`;
+        ? `\`${originalActions[0]}\` expands to ${totalExpandedActionsCount} action(s):`
+        : `${originalActions.length} wildcard patterns expand to ${totalExpandedActionsCount} action(s):`;
     const patterns = originalActions.length > 1
         ? `\n**Patterns:**\n${originalActions.map((a) => `- \`${a}\``).join('\n')}`
         : '';
     const warning = redundantActions && redundantActions.length > 0
         ? `\n\n**⚠️ Redundant actions detected:**\nThe following explicit actions are already covered by the wildcard pattern(s) above:\n${redundantActions.map((a) => `- \`${a}\``).join('\n')}`
         : '';
-    const actionsList = expandedActions.map((a) => `1. ${formatActionWithLink(a)}`).join('\n');
-    const actionsBlock = expandedActions.length > collapseThreshold
-        ? `<details>
+    const truncationNotice = displayedActions.length < totalExpandedActionsCount
+        ? createTruncationNotice(displayedActions.length, totalExpandedActionsCount, truncationUrl)
+        : '';
+    const actionsList = displayedActions.map((a) => `1. ${formatActionWithLink(a)}`).join('\n');
+    const actionsBlock = displayedActions.length === 0
+        ? '_Full expanded list omitted from this comment._'
+        : displayedActions.length > collapseThreshold
+            ? `<details>
 <summary>Click to expand</summary>
 
 ${actionsList}
 
 </details>`
-        : actionsList;
+            : actionsList;
     return `**IAM Wildcard Expansion**
 
-${header}${patterns}${warning}
+${header}${patterns}${warning}${truncationNotice}
 
 ${actionsBlock}`;
+}
+function createMinimalCommentBody(truncationUrl) {
+    const logMessage = truncationUrl
+        ? ` The full expanded list is in the [workflow run logs](${truncationUrl}).`
+        : '';
+    return `**IAM Wildcard Expansion**
+
+Expanded actions were omitted from this comment to stay within GitHub limits.${logMessage}`;
+}
+function formatCommentResult(originalActions, expandedActions, options = {}) {
+    const { maxCommentBodyLength = MAX_COMMENT_BODY_LENGTH } = options;
+    const safeMaxCommentBodyLength = Math.max(1, maxCommentBodyLength);
+    const fullBody = buildCommentBody(originalActions, expandedActions, expandedActions.length, options);
+    if (fullBody.length <= safeMaxCommentBodyLength) {
+        return {
+            body: fullBody,
+            renderedActionsCount: expandedActions.length,
+            truncated: false,
+        };
+    }
+    let bestCount = 0;
+    let bestBody = '';
+    let low = 0;
+    let high = expandedActions.length;
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const candidateBody = buildCommentBody(originalActions, expandedActions.slice(0, mid), expandedActions.length, options);
+        if (candidateBody.length <= safeMaxCommentBodyLength) {
+            bestCount = mid;
+            bestBody = candidateBody;
+            low = mid + 1;
+        }
+        else {
+            high = mid - 1;
+        }
+    }
+    if (bestBody === '') {
+        bestBody = createMinimalCommentBody(options.truncationUrl);
+    }
+    return {
+        body: bestBody,
+        renderedActionsCount: bestCount,
+        truncated: true,
+    };
+}
+function formatComment(originalActions, expandedActions, options = {}) {
+    return formatCommentResult(originalActions, expandedActions, options).body;
 }
 
 ;// CONCATENATED MODULE: ./src/diff.ts
@@ -59055,8 +59117,10 @@ function findRedundantActions(explicitActions, expandedActions) {
     }
     return explicitActions.filter((action) => allExpanded.has(action.toLowerCase()));
 }
-function createReviewComments(blocks, expandedActions, redundantActions, collapseThreshold) {
-    return blocks.flatMap((block) => {
+function buildReviewComments(blocks, expandedActions, redundantActions, collapseThreshold, options = {}) {
+    const comments = [];
+    const truncatedComments = [];
+    for (const block of blocks) {
         const originalActions = [];
         const allExpanded = [];
         for (const action of block.actions) {
@@ -59066,18 +59130,38 @@ function createReviewComments(blocks, expandedActions, redundantActions, collaps
                 allExpanded.push(...expanded);
             }
         }
-        if (allExpanded.length === 0)
-            return [];
+        if (allExpanded.length === 0) {
+            continue;
+        }
         const uniqueExpanded = [...new Set(allExpanded)].toSorted((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-        const options = { collapseThreshold, redundantActions };
-        return {
+        const formatOptions = {
+            collapseThreshold,
+            redundantActions,
+            truncationUrl: options.truncationUrl,
+            maxCommentBodyLength: options.maxCommentBodyLength,
+        };
+        const formattedComment = formatCommentResult(originalActions, uniqueExpanded, formatOptions);
+        comments.push({
             path: block.file,
             line: block.endLine,
-            body: formatComment(originalActions, uniqueExpanded, options),
-        };
-    });
+            body: formattedComment.body,
+        });
+        if (formattedComment.truncated) {
+            truncatedComments.push({
+                file: block.file,
+                line: block.endLine,
+                originalActions,
+                expandedActions: uniqueExpanded,
+                renderedActionsCount: formattedComment.renderedActionsCount,
+            });
+        }
+    }
+    return { comments, truncatedComments };
 }
-function processFiles(files, filePatterns, collapseThreshold) {
+function createReviewComments(blocks, expandedActions, redundantActions, collapseThreshold, options = {}) {
+    return buildReviewComments(blocks, expandedActions, redundantActions, collapseThreshold, options).comments;
+}
+function processFiles(files, filePatterns, collapseThreshold, options = {}) {
     const filteredFiles = filePatterns.length > 0
         ? files.filter((f) => matchesPatterns(f.filename, filePatterns))
         : files;
@@ -59086,6 +59170,7 @@ function processFiles(files, filePatterns, collapseThreshold) {
             comments: [],
             redundantActions: [],
             stats: { filesScanned: 0, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+            truncatedComments: [],
         };
     }
     const { wildcardMatches, explicitActions } = extractFromDiff(filteredFiles);
@@ -59094,6 +59179,7 @@ function processFiles(files, filePatterns, collapseThreshold) {
             comments: [],
             redundantActions: [],
             stats: { filesScanned: filteredFiles.length, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+            truncatedComments: [],
         };
     }
     const blocks = groupIntoConsecutiveBlocks(wildcardMatches);
@@ -59109,12 +59195,13 @@ function processFiles(files, filePatterns, collapseThreshold) {
                 blocksCreated: blocks.length,
                 actionsExpanded: 0,
             },
+            truncatedComments: [],
         };
     }
     const redundantActions = findRedundantActions(explicitActions, expandedActions);
-    const comments = createReviewComments(blocks, expandedActions, redundantActions, collapseThreshold);
+    const reviewComments = buildReviewComments(blocks, expandedActions, redundantActions, collapseThreshold, options);
     return {
-        comments,
+        comments: reviewComments.comments,
         redundantActions,
         stats: {
             filesScanned: filteredFiles.length,
@@ -59122,6 +59209,128 @@ function processFiles(files, filePatterns, collapseThreshold) {
             blocksCreated: blocks.length,
             actionsExpanded: expandedActions.size,
         },
+        truncatedComments: reviewComments.truncatedComments,
+    };
+}
+
+;// CONCATENATED MODULE: ./src/github.ts
+function getAnchorKey(path, line) {
+    return JSON.stringify([path, line]);
+}
+function getExistingCommentAnchorKey(comment) {
+    if (!comment.path) {
+        return null;
+    }
+    const line = comment.line ?? comment.original_line;
+    if (line === null || line === undefined) {
+        return null;
+    }
+    return getAnchorKey(comment.path, line);
+}
+async function listPullRequestFiles(octokit, owner, repo, pullNumber) {
+    return octokit.paginate(octokit.rest.pulls.listFiles, {
+        owner,
+        repo,
+        pull_number: pullNumber,
+        per_page: 100,
+    });
+}
+async function listActionReviewComments(octokit, owner, repo, pullNumber, marker) {
+    const reviewComments = await octokit.paginate(octokit.rest.pulls.listReviewComments, {
+        owner,
+        repo,
+        pull_number: pullNumber,
+        per_page: 100,
+    });
+    return reviewComments.filter((comment) => comment.body.includes(marker));
+}
+async function syncReviewComments(octokit, params) {
+    const { owner, repo, pullNumber, commitSha, comments, existingComments } = params;
+    const existingCommentsByAnchor = new Map();
+    const staleComments = [];
+    for (const comment of existingComments) {
+        const anchorKey = getExistingCommentAnchorKey(comment);
+        if (!anchorKey) {
+            staleComments.push(comment);
+            continue;
+        }
+        const commentsAtAnchor = existingCommentsByAnchor.get(anchorKey);
+        if (commentsAtAnchor) {
+            commentsAtAnchor.push(comment);
+        }
+        else {
+            existingCommentsByAnchor.set(anchorKey, [comment]);
+        }
+    }
+    const commentsToCreate = [];
+    const commentsToUpdate = [];
+    let unchangedCount = 0;
+    for (const comment of comments) {
+        const anchorKey = getAnchorKey(comment.path, comment.line);
+        const existingAtAnchor = existingCommentsByAnchor.get(anchorKey);
+        if (!existingAtAnchor || existingAtAnchor.length === 0) {
+            commentsToCreate.push(comment);
+            continue;
+        }
+        const exactMatch = existingAtAnchor.find((existingComment) => existingComment.body === comment.body);
+        if (exactMatch) {
+            unchangedCount += 1;
+            staleComments.push(...existingAtAnchor.filter((existingComment) => existingComment.id !== exactMatch.id));
+            existingCommentsByAnchor.delete(anchorKey);
+            continue;
+        }
+        const [commentToUpdate, ...duplicateComments] = existingAtAnchor;
+        if (commentToUpdate) {
+            commentsToUpdate.push({
+                ...commentToUpdate,
+                body: comment.body,
+            });
+        }
+        staleComments.push(...duplicateComments);
+        existingCommentsByAnchor.delete(anchorKey);
+    }
+    for (const unmatchedComments of existingCommentsByAnchor.values()) {
+        staleComments.push(...unmatchedComments);
+    }
+    for (const comment of commentsToUpdate) {
+        await octokit.rest.pulls.updateReviewComment({
+            owner,
+            repo,
+            comment_id: comment.id,
+            body: comment.body,
+        });
+    }
+    if (commentsToCreate.length > 0) {
+        await octokit.rest.pulls.createReview({
+            owner,
+            repo,
+            pull_number: pullNumber,
+            commit_id: commitSha,
+            event: 'COMMENT',
+            comments: commentsToCreate,
+        });
+    }
+    let deletedCount = 0;
+    let failedDeleteCount = 0;
+    for (const comment of staleComments) {
+        try {
+            await octokit.rest.pulls.deleteReviewComment({
+                owner,
+                repo,
+                comment_id: comment.id,
+            });
+            deletedCount += 1;
+        }
+        catch {
+            failedDeleteCount += 1;
+        }
+    }
+    return {
+        createdCount: commentsToCreate.length,
+        updatedCount: commentsToUpdate.length,
+        unchangedCount,
+        deletedCount,
+        failedDeleteCount,
     };
 }
 
@@ -59129,17 +59338,40 @@ function processFiles(files, filePatterns, collapseThreshold) {
 
 
 
-async function deleteExistingComments(octokit, owner, repo, pullNumber) {
-    const reviewComments = await octokit.paginate(octokit.rest.pulls.listReviewComments, { owner, repo, pull_number: pullNumber, per_page: 100 });
-    const ourComments = reviewComments.filter((c) => c.body.includes(COMMENT_MARKER));
-    for (const comment of ourComments) {
-        await octokit.rest.pulls.deleteReviewComment({
-            owner,
-            repo,
-            comment_id: comment.id,
-        });
+
+function getWorkflowRunUrl(owner, repo) {
+    const runId = process.env.GITHUB_RUN_ID;
+    if (!runId) {
+        return undefined;
     }
-    return ourComments.length;
+    const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+    return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
+}
+function logTruncatedComments(truncatedComments, workflowRunUrl) {
+    if (truncatedComments.length === 0) {
+        return;
+    }
+    const logLocation = workflowRunUrl ? ` Full lists are available in this workflow run: ${workflowRunUrl}` : '';
+    warning(`Truncated ${truncatedComments.length} review comment(s) to stay within GitHub comment limits.${logLocation}`);
+    for (const truncatedComment of truncatedComments) {
+        info([
+            `Full IAM expansion for ${truncatedComment.file}:${truncatedComment.line}`,
+            `Rendered ${truncatedComment.renderedActionsCount} of ${truncatedComment.expandedActions.length} action(s) in the PR comment.`,
+            `Wildcard patterns: ${truncatedComment.originalActions.join(', ')}`,
+            ...truncatedComment.expandedActions.map((action) => `- ${action}`),
+        ].join('\n'));
+    }
+}
+function logReviewCommentSyncResult(result) {
+    if (result.createdCount > 0 || result.updatedCount > 0 || result.unchangedCount > 0) {
+        info(`Synchronized comments: ${result.createdCount} created, ${result.updatedCount} updated, ${result.unchangedCount} unchanged`);
+    }
+    if (result.deletedCount > 0) {
+        info(`Deleted ${result.deletedCount} existing comment(s) from previous runs`);
+    }
+    if (result.failedDeleteCount > 0) {
+        warning(`Failed to delete ${result.failedDeleteCount} stale comment(s) from previous runs`);
+    }
 }
 async function run() {
     try {
@@ -59158,28 +59390,46 @@ async function run() {
         const { owner, repo } = context.repo;
         const pullNumber = context.payload.pull_request.number;
         const commitSha = context.payload.pull_request.head.sha;
+        const workflowRunUrl = getWorkflowRunUrl(owner, repo);
         info(`Analyzing PR #${pullNumber} in ${owner}/${repo}`);
-        const deletedCount = await deleteExistingComments(octokit, owner, repo, pullNumber);
-        if (deletedCount > 0) {
-            info(`Deleted ${deletedCount} existing comment(s) from previous runs`);
-        }
-        const { data: files } = await octokit.rest.pulls.listFiles({
-            owner,
-            repo,
-            pull_number: pullNumber,
-        });
-        const { comments, redundantActions, stats } = processFiles(files, filePatterns, collapseThreshold);
+        const existingComments = await listActionReviewComments(octokit, owner, repo, pullNumber, COMMENT_MARKER);
+        const files = await listPullRequestFiles(octokit, owner, repo, pullNumber);
+        const { comments, redundantActions, stats, truncatedComments } = processFiles(files, filePatterns, collapseThreshold, { truncationUrl: workflowRunUrl });
         if (stats.filesScanned === 0) {
+            logReviewCommentSyncResult(await syncReviewComments(octokit, {
+                owner,
+                repo,
+                pullNumber,
+                commitSha,
+                comments: [],
+                existingComments,
+            }));
             info('No files matched the configured patterns.');
             return;
         }
         info(`Scanned ${stats.filesScanned} file(s)`);
         if (stats.wildcardsFound === 0) {
+            logReviewCommentSyncResult(await syncReviewComments(octokit, {
+                owner,
+                repo,
+                pullNumber,
+                commitSha,
+                comments: [],
+                existingComments,
+            }));
             info('No IAM wildcard actions found in the changes.');
             return;
         }
         info(`Found ${stats.wildcardsFound} wildcard(s), grouped into ${stats.blocksCreated} block(s)`);
         if (stats.actionsExpanded === 0) {
+            logReviewCommentSyncResult(await syncReviewComments(octokit, {
+                owner,
+                repo,
+                pullNumber,
+                commitSha,
+                comments: [],
+                existingComments,
+            }));
             info('No wildcard actions could be expanded.');
             return;
         }
@@ -59187,18 +59437,27 @@ async function run() {
             warning(`Found ${redundantActions.length} redundant action(s): ${redundantActions.join(', ')}`);
         }
         if (comments.length === 0) {
+            logReviewCommentSyncResult(await syncReviewComments(octokit, {
+                owner,
+                repo,
+                pullNumber,
+                commitSha,
+                comments: [],
+                existingComments,
+            }));
             info('No comments to post.');
             return;
         }
-        await octokit.rest.pulls.createReview({
+        logTruncatedComments(truncatedComments, workflowRunUrl);
+        const syncResult = await syncReviewComments(octokit, {
             owner,
             repo,
-            pull_number: pullNumber,
-            commit_id: commitSha,
-            event: 'COMMENT',
             comments,
+            pullNumber,
+            commitSha,
+            existingComments,
         });
-        info(`Posted review with ${comments.length} comment(s)`);
+        logReviewCommentSyncResult(syncResult);
     }
     catch (error) {
         setFailed(error instanceof Error ? error.message : 'An unexpected error occurred');

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -303,6 +303,29 @@ describe('syncReviewComments', () => {
     });
   });
 
+  it('treats comments with a path but no line information as stale', async () => {
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [],
+      existingComments: [{ id: 1001, path: 'policy.tf', body: '**IAM Wildcard Expansion**\n\nstale body' }],
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 0,
+      unchangedCount: 0,
+      deletedCount: 1,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.deleteReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+    });
+  });
+
   it('continues deleting stale comments when one delete fails', async () => {
     const octokit = makeOctokit();
     octokit.rest.pulls.deleteReviewComment

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { listPullRequestFiles } from './github.js';
-import type { PullRequestFile } from './types.js';
+import {
+  listPullRequestFiles,
+  listActionReviewComments,
+  syncReviewComments,
+} from './github.js';
+import type { PullRequestFile, PullRequestReviewComment, ReviewComment } from './types.js';
 
 describe('listPullRequestFiles', () => {
   it('paginates pull request files with a page size of 100', async () => {
@@ -29,5 +33,300 @@ describe('listPullRequestFiles', () => {
       pull_number: 42,
       per_page: 100,
     });
+  });
+});
+
+describe('listActionReviewComments', () => {
+  it('returns only comments that include the action marker', async () => {
+    const reviewComments: PullRequestReviewComment[] = [
+      { id: 1, body: '**IAM Wildcard Expansion**\n\ncomment body', path: 'policy.tf', line: 10 },
+      { id: 2, body: 'other bot comment', path: 'policy.tf', line: 20 },
+      { id: 3, body: '**IAM Wildcard Expansion**\n\nanother comment body', path: 'policy.tf', line: 30 },
+    ];
+    const listReviewComments = {};
+    const paginate = vi.fn().mockResolvedValue(reviewComments);
+    const octokit = {
+      paginate,
+      rest: {
+        pulls: {
+          listReviewComments,
+        },
+      },
+    };
+
+    const result = await listActionReviewComments(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+      '**IAM Wildcard Expansion**',
+    );
+
+    expect(result).toEqual([reviewComments[0], reviewComments[2]]);
+    expect(paginate).toHaveBeenCalledWith(listReviewComments, {
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      pull_number: 42,
+      per_page: 100,
+    });
+  });
+});
+
+describe('syncReviewComments', () => {
+  const baseParams = {
+    owner: 'thekbb',
+    repo: 'expand-aws-iam-wildcards',
+    pullNumber: 42,
+    commitSha: 'abc123',
+  };
+
+  function makeOctokit() {
+    return {
+      rest: {
+        pulls: {
+          createReview: vi.fn().mockResolvedValue({}),
+          updateReviewComment: vi.fn().mockResolvedValue({}),
+          deleteReviewComment: vi.fn().mockResolvedValue({}),
+        },
+      },
+    };
+  }
+
+  it('leaves matching comments alone', async () => {
+    const existingComments: PullRequestReviewComment[] = [
+      { id: 1001, path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nsame body' },
+    ];
+    const comments: ReviewComment[] = [
+      { path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nsame body' },
+    ];
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments,
+      existingComments,
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 0,
+      unchangedCount: 1,
+      deletedCount: 0,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.createReview).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.updateReviewComment).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.deleteReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('updates an existing comment in place when only the body changed', async () => {
+    const existingComments: PullRequestReviewComment[] = [
+      { id: 1001, path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nold body' },
+    ];
+    const comments: ReviewComment[] = [
+      { path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nnew body' },
+    ];
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments,
+      existingComments,
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 1,
+      unchangedCount: 0,
+      deletedCount: 0,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.updateReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+      body: '**IAM Wildcard Expansion**\n\nnew body',
+    });
+    expect(octokit.rest.pulls.createReview).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.deleteReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('creates new comments before deleting stale comments', async () => {
+    const comments: ReviewComment[] = [
+      { path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nnew body' },
+    ];
+    const existingComments: PullRequestReviewComment[] = [
+      { id: 1001, path: 'policy.tf', line: 20, body: '**IAM Wildcard Expansion**\n\nstale body' },
+    ];
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments,
+      existingComments,
+    });
+
+    expect(result).toEqual({
+      createdCount: 1,
+      updatedCount: 0,
+      unchangedCount: 0,
+      deletedCount: 1,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.createReview).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      pull_number: 42,
+      commit_id: 'abc123',
+      event: 'COMMENT',
+      comments,
+    });
+    expect(octokit.rest.pulls.deleteReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+    });
+    expect(octokit.rest.pulls.createReview.mock.invocationCallOrder[0]).toBeLessThan(
+      octokit.rest.pulls.deleteReviewComment.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not delete existing comments when creating new comments fails', async () => {
+    const octokit = makeOctokit();
+    octokit.rest.pulls.createReview.mockRejectedValue(new Error('review failed'));
+
+    await expect(syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [{ path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nnew body' }],
+      existingComments: [{ id: 1001, path: 'policy.tf', line: 20, body: '**IAM Wildcard Expansion**\n\nstale body' }],
+    })).rejects.toThrow('review failed');
+
+    expect(octokit.rest.pulls.deleteReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('deletes stale comments when there are no new comments to post', async () => {
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [],
+      existingComments: [{ id: 1001, path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nstale body' }],
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 0,
+      unchangedCount: 0,
+      deletedCount: 1,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.createReview).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.updateReviewComment).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.deleteReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+    });
+  });
+
+  it('deletes duplicate comments when one exact match is kept', async () => {
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [{ path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nsame body' }],
+      existingComments: [
+        { id: 1001, path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nsame body' },
+        { id: 1002, path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nsame body' },
+      ],
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 0,
+      unchangedCount: 1,
+      deletedCount: 1,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.updateReviewComment).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.deleteReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1002,
+    });
+  });
+
+  it('uses original_line when line is unavailable on an existing comment', async () => {
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [{ path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nnew body' }],
+      existingComments: [{ id: 1001, path: 'policy.tf', line: null, original_line: 10, body: '**IAM Wildcard Expansion**\n\nold body' }],
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 1,
+      unchangedCount: 0,
+      deletedCount: 0,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.updateReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+      body: '**IAM Wildcard Expansion**\n\nnew body',
+    });
+  });
+
+  it('treats comments without a usable anchor as stale', async () => {
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [],
+      existingComments: [{ id: 1001, body: '**IAM Wildcard Expansion**\n\nstale body' }],
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 0,
+      unchangedCount: 0,
+      deletedCount: 1,
+      failedDeleteCount: 0,
+    });
+    expect(octokit.rest.pulls.deleteReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+    });
+  });
+
+  it('continues deleting stale comments when one delete fails', async () => {
+    const octokit = makeOctokit();
+    octokit.rest.pulls.deleteReviewComment
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('delete failed'))
+      .mockResolvedValueOnce({});
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [],
+      existingComments: [
+        { id: 1001, path: 'policy.tf', line: 10, body: '**IAM Wildcard Expansion**\n\nstale body 1' },
+        { id: 1002, path: 'policy.tf', line: 20, body: '**IAM Wildcard Expansion**\n\nstale body 2' },
+        { id: 1003, path: 'policy.tf', line: 30, body: '**IAM Wildcard Expansion**\n\nstale body 3' },
+      ],
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 0,
+      unchangedCount: 0,
+      deletedCount: 2,
+      failedDeleteCount: 1,
+    });
+    expect(octokit.rest.pulls.deleteReviewComment).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,6 @@
-import type { PullRequestFile } from './types.js';
+import type { PullRequestFile, PullRequestReviewComment, ReviewComment } from './types.js';
 
-interface PullRequestFilesClient {
+interface PaginatedPullsClient<TItem> {
   readonly paginate: (
     route: unknown,
     parameters: {
@@ -9,16 +9,77 @@ interface PullRequestFilesClient {
       pull_number: number;
       per_page: number;
     },
-  ) => Promise<PullRequestFile[]>;
+  ) => Promise<TItem[]>;
   readonly rest: {
     readonly pulls: {
-      readonly listFiles: unknown;
+      readonly listFiles?: unknown;
+      readonly listReviewComments?: unknown;
     };
   };
 }
 
+interface ReviewSyncClient {
+  readonly rest: {
+    readonly pulls: {
+      readonly createReview: (parameters: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+        commit_id: string;
+        event: 'COMMENT';
+        comments: ReviewComment[];
+      }) => Promise<unknown>;
+      readonly updateReviewComment: (parameters: {
+        owner: string;
+        repo: string;
+        comment_id: number;
+        body: string;
+      }) => Promise<unknown>;
+      readonly deleteReviewComment: (parameters: {
+        owner: string;
+        repo: string;
+        comment_id: number;
+      }) => Promise<unknown>;
+    };
+  };
+}
+
+export interface SyncReviewCommentsParams {
+  readonly owner: string;
+  readonly repo: string;
+  readonly pullNumber: number;
+  readonly commitSha: string;
+  readonly comments: ReviewComment[];
+  readonly existingComments: readonly PullRequestReviewComment[];
+}
+
+export interface SyncReviewCommentsResult {
+  readonly createdCount: number;
+  readonly updatedCount: number;
+  readonly unchangedCount: number;
+  readonly deletedCount: number;
+  readonly failedDeleteCount: number;
+}
+
+function getAnchorKey(path: string, line: number): string {
+  return JSON.stringify([path, line]);
+}
+
+function getExistingCommentAnchorKey(comment: PullRequestReviewComment): string | null {
+  if (!comment.path) {
+    return null;
+  }
+
+  const line = comment.line ?? comment.original_line;
+  if (line === null || line === undefined) {
+    return null;
+  }
+
+  return getAnchorKey(comment.path, line);
+}
+
 export async function listPullRequestFiles(
-  octokit: PullRequestFilesClient,
+  octokit: PaginatedPullsClient<PullRequestFile>,
   owner: string,
   repo: string,
   pullNumber: number,
@@ -29,4 +90,125 @@ export async function listPullRequestFiles(
     pull_number: pullNumber,
     per_page: 100,
   });
+}
+
+export async function listActionReviewComments(
+  octokit: PaginatedPullsClient<PullRequestReviewComment>,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  marker: string,
+): Promise<PullRequestReviewComment[]> {
+  const reviewComments = await octokit.paginate(octokit.rest.pulls.listReviewComments, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100,
+  });
+
+  return reviewComments.filter((comment) => comment.body.includes(marker));
+}
+
+export async function syncReviewComments(
+  octokit: ReviewSyncClient,
+  params: SyncReviewCommentsParams,
+): Promise<SyncReviewCommentsResult> {
+  const { owner, repo, pullNumber, commitSha, comments, existingComments } = params;
+  const existingCommentsByAnchor = new Map<string, PullRequestReviewComment[]>();
+  const staleComments: PullRequestReviewComment[] = [];
+
+  for (const comment of existingComments) {
+    const anchorKey = getExistingCommentAnchorKey(comment);
+    if (!anchorKey) {
+      staleComments.push(comment);
+      continue;
+    }
+
+    const commentsAtAnchor = existingCommentsByAnchor.get(anchorKey);
+    if (commentsAtAnchor) {
+      commentsAtAnchor.push(comment);
+    } else {
+      existingCommentsByAnchor.set(anchorKey, [comment]);
+    }
+  }
+
+  const commentsToCreate: ReviewComment[] = [];
+  const commentsToUpdate: PullRequestReviewComment[] = [];
+  let unchangedCount = 0;
+
+  for (const comment of comments) {
+    const anchorKey = getAnchorKey(comment.path, comment.line);
+    const existingAtAnchor = existingCommentsByAnchor.get(anchorKey);
+
+    if (!existingAtAnchor || existingAtAnchor.length === 0) {
+      commentsToCreate.push(comment);
+      continue;
+    }
+
+    const exactMatch = existingAtAnchor.find((existingComment) => existingComment.body === comment.body);
+    if (exactMatch) {
+      unchangedCount += 1;
+      staleComments.push(...existingAtAnchor.filter((existingComment) => existingComment.id !== exactMatch.id));
+      existingCommentsByAnchor.delete(anchorKey);
+      continue;
+    }
+
+    const [commentToUpdate, ...duplicateComments] = existingAtAnchor;
+    if (commentToUpdate) {
+      commentsToUpdate.push({
+        ...commentToUpdate,
+        body: comment.body,
+      });
+    }
+    staleComments.push(...duplicateComments);
+    existingCommentsByAnchor.delete(anchorKey);
+  }
+
+  for (const unmatchedComments of existingCommentsByAnchor.values()) {
+    staleComments.push(...unmatchedComments);
+  }
+
+  for (const comment of commentsToUpdate) {
+    await octokit.rest.pulls.updateReviewComment({
+      owner,
+      repo,
+      comment_id: comment.id,
+      body: comment.body,
+    });
+  }
+
+  if (commentsToCreate.length > 0) {
+    await octokit.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      commit_id: commitSha,
+      event: 'COMMENT',
+      comments: commentsToCreate,
+    });
+  }
+
+  let deletedCount = 0;
+  let failedDeleteCount = 0;
+
+  for (const comment of staleComments) {
+    try {
+      await octokit.rest.pulls.deleteReviewComment({
+        owner,
+        repo,
+        comment_id: comment.id,
+      });
+      deletedCount += 1;
+    } catch {
+      failedDeleteCount += 1;
+    }
+  }
+
+  return {
+    createdCount: commentsToCreate.length,
+    updatedCount: commentsToUpdate.length,
+    unchangedCount,
+    deletedCount,
+    failedDeleteCount,
+  };
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -153,13 +153,12 @@ export async function syncReviewComments(
       continue;
     }
 
-    const [commentToUpdate, ...duplicateComments] = existingAtAnchor;
-    if (commentToUpdate) {
-      commentsToUpdate.push({
-        ...commentToUpdate,
-        body: comment.body,
-      });
-    }
+    const [commentToUpdate, ...duplicateComments] =
+      existingAtAnchor as [PullRequestReviewComment, ...PullRequestReviewComment[]];
+    commentsToUpdate.push({
+      ...commentToUpdate,
+      body: comment.body,
+    });
     staleComments.push(...duplicateComments);
     existingCommentsByAnchor.delete(anchorKey);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,12 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 import { processFiles, COMMENT_MARKER, type TruncatedComment } from './action.js';
-import { listPullRequestFiles } from './github.js';
-
-type Octokit = ReturnType<typeof github.getOctokit>;
+import {
+  listActionReviewComments,
+  listPullRequestFiles,
+  syncReviewComments,
+  type SyncReviewCommentsResult,
+} from './github.js';
 
 function getWorkflowRunUrl(owner: string, repo: string): string | undefined {
   const runId = process.env.GITHUB_RUN_ID;
@@ -39,28 +42,20 @@ function logTruncatedComments(
   }
 }
 
-async function deleteExistingComments(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  pullNumber: number,
-): Promise<number> {
-  const reviewComments = await octokit.paginate(
-    octokit.rest.pulls.listReviewComments,
-    { owner, repo, pull_number: pullNumber, per_page: 100 }
-  );
-
-  const ourComments = reviewComments.filter((c) => c.body.includes(COMMENT_MARKER));
-
-  for (const comment of ourComments) {
-    await octokit.rest.pulls.deleteReviewComment({
-      owner,
-      repo,
-      comment_id: comment.id,
-    });
+function logReviewCommentSyncResult(result: SyncReviewCommentsResult): void {
+  if (result.createdCount > 0 || result.updatedCount > 0 || result.unchangedCount > 0) {
+    core.info(
+      `Synchronized comments: ${result.createdCount} created, ${result.updatedCount} updated, ${result.unchangedCount} unchanged`
+    );
   }
 
-  return ourComments.length;
+  if (result.deletedCount > 0) {
+    core.info(`Deleted ${result.deletedCount} existing comment(s) from previous runs`);
+  }
+
+  if (result.failedDeleteCount > 0) {
+    core.warning(`Failed to delete ${result.failedDeleteCount} stale comment(s) from previous runs`);
+  }
 }
 
 async function run(): Promise<void> {
@@ -86,10 +81,13 @@ async function run(): Promise<void> {
 
     core.info(`Analyzing PR #${pullNumber} in ${owner}/${repo}`);
 
-    const deletedCount = await deleteExistingComments(octokit, owner, repo, pullNumber);
-    if (deletedCount > 0) {
-      core.info(`Deleted ${deletedCount} existing comment(s) from previous runs`);
-    }
+    const existingComments = await listActionReviewComments(
+      octokit,
+      owner,
+      repo,
+      pullNumber,
+      COMMENT_MARKER,
+    );
 
     const files = await listPullRequestFiles(octokit, owner, repo, pullNumber);
 
@@ -101,6 +99,14 @@ async function run(): Promise<void> {
     );
 
     if (stats.filesScanned === 0) {
+      logReviewCommentSyncResult(await syncReviewComments(octokit, {
+        owner,
+        repo,
+        pullNumber,
+        commitSha,
+        comments: [],
+        existingComments,
+      }));
       core.info('No files matched the configured patterns.');
       return;
     }
@@ -108,6 +114,14 @@ async function run(): Promise<void> {
     core.info(`Scanned ${stats.filesScanned} file(s)`);
 
     if (stats.wildcardsFound === 0) {
+      logReviewCommentSyncResult(await syncReviewComments(octokit, {
+        owner,
+        repo,
+        pullNumber,
+        commitSha,
+        comments: [],
+        existingComments,
+      }));
       core.info('No IAM wildcard actions found in the changes.');
       return;
     }
@@ -115,6 +129,14 @@ async function run(): Promise<void> {
     core.info(`Found ${stats.wildcardsFound} wildcard(s), grouped into ${stats.blocksCreated} block(s)`);
 
     if (stats.actionsExpanded === 0) {
+      logReviewCommentSyncResult(await syncReviewComments(octokit, {
+        owner,
+        repo,
+        pullNumber,
+        commitSha,
+        comments: [],
+        existingComments,
+      }));
       core.info('No wildcard actions could be expanded.');
       return;
     }
@@ -124,22 +146,29 @@ async function run(): Promise<void> {
     }
 
     if (comments.length === 0) {
+      logReviewCommentSyncResult(await syncReviewComments(octokit, {
+        owner,
+        repo,
+        pullNumber,
+        commitSha,
+        comments: [],
+        existingComments,
+      }));
       core.info('No comments to post.');
       return;
     }
 
     logTruncatedComments(truncatedComments, workflowRunUrl);
 
-    await octokit.rest.pulls.createReview({
+    const syncResult = await syncReviewComments(octokit, {
       owner,
       repo,
-      pull_number: pullNumber,
-      commit_id: commitSha,
-      event: 'COMMENT',
       comments,
+      pullNumber,
+      commitSha,
+      existingComments,
     });
-
-    core.info(`Posted review with ${comments.length} comment(s)`);
+    logReviewCommentSyncResult(syncResult);
   } catch (error) {
     core.setFailed(error instanceof Error ? error.message : 'An unexpected error occurred');
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,14 @@ export interface ReviewComment {
   readonly body: string;
 }
 
+export interface PullRequestReviewComment {
+  readonly id: number;
+  readonly body: string;
+  readonly path?: string;
+  readonly line?: number | null;
+  readonly original_line?: number | null;
+}
+
 export interface PullRequestFile {
   readonly filename: string;
   readonly patch?: string;


### PR DESCRIPTION
The previous flow recreated comments too aggressively. Even when a wildcard block stayed on the same file and line, the bot could churn comments and discard reply threads. This change makes the action behave more like a sync against the desired comment state.

New behavior

- same file/line + same body: no change
- same file/line + different body: update in place
- new file/line: create a new comment
- old file/line no longer needed: delete the stale comment