### PR TITLE
Ignore diff newline markers when tracking review anchors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36508,6 +36508,9 @@ function formatComment(originalActions, expandedActions, options = {}) {
 
 ;// CONCATENATED MODULE: ./src/diff.ts
 
+function isNoNewlineMarker(line) {
+    return line === '\\ No newline at end of file';
+}
 function extractFromPatch(patch, filename) {
     const wildcardMatches = [];
     let currentLine = 0;
@@ -36515,6 +36518,9 @@ function extractFromPatch(patch, filename) {
         const hunkStart = parseHunkHeader(line);
         if (hunkStart !== null) {
             currentLine = hunkStart - 1;
+            continue;
+        }
+        if (isNoNewlineMarker(line)) {
             continue;
         }
         if (line.startsWith('-'))

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -203,4 +203,35 @@ describe('extractFromDiff', () => {
     expect(wildcardMatches).toHaveLength(1);
     expect(wildcardMatches[0]?.action).toBe('s3:Get*');
   });
+
+  it('does not count the no-newline marker as a destination line', () => {
+    const files = [
+      {
+        filename: 'policy.json',
+        patch: `@@ -1,1 +1,1 @@
+-  "Action": "s3:GetObject"
++  "Action": "s3:Get*"
+\\ No newline at end of file
+@@ -10,2 +10,3 @@
+ {
++  "Action": "ec2:Describe*"
+ }
+}`,
+      },
+    ];
+
+    const { wildcardMatches } = extractFromDiff(files);
+
+    expect(wildcardMatches).toHaveLength(2);
+    expect(wildcardMatches[0]).toEqual({
+      action: 's3:Get*',
+      line: 1,
+      file: 'policy.json',
+    });
+    expect(wildcardMatches[1]).toEqual({
+      action: 'ec2:Describe*',
+      line: 11,
+      file: 'policy.json',
+    });
+  });
 });

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -5,6 +5,10 @@ export interface DiffResults {
   readonly wildcardMatches: WildcardMatch[];
 }
 
+function isNoNewlineMarker(line: string): boolean {
+  return line === '\\ No newline at end of file';
+}
+
 function extractFromPatch(patch: string, filename: string): DiffResults {
   const wildcardMatches: WildcardMatch[] = [];
   let currentLine = 0;
@@ -13,6 +17,10 @@ function extractFromPatch(patch: string, filename: string): DiffResults {
     const hunkStart = parseHunkHeader(line);
     if (hunkStart !== null) {
       currentLine = hunkStart - 1;
+      continue;
+    }
+
+    if (isNoNewlineMarker(line)) {
       continue;
     }
 


### PR DESCRIPTION
Skip the `"\ No newline at end of file"` patch marker during diff parsing so it does not shift destination line numbers for later wildcard matches.

Add a regression test for a multi-hunk patch with the newline marker.