### PR TITLE
Validate collapse-threshold input before running the action.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   syncReviewComments,
   type SyncReviewCommentsResult,
 } from './github.js';
+import { parseCollapseThreshold } from './inputs.js';
 
 function getWorkflowRunUrl(owner: string, repo: string): string | undefined {
   const runId = process.env.GITHUB_RUN_ID;
@@ -67,7 +68,7 @@ function logReviewCommentSyncResult(result: SyncReviewCommentsResult): void {
 async function run(): Promise<void> {
   try {
     const token = core.getInput('github-token', { required: true });
-    const collapseThreshold = parseInt(core.getInput('collapse-threshold') || '5', 10);
+    const collapseThreshold = parseCollapseThreshold(core.getInput('collapse-threshold'));
     const filePatterns = core.getInput('file-patterns')
       .split(',')
       .map((p) => p.trim())

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_COLLAPSE_THRESHOLD,
+  parseCollapseThreshold,
+} from './inputs.js';
+
+describe('parseCollapseThreshold', () => {
+  it('returns the default threshold for undefined input', () => {
+    expect(parseCollapseThreshold(undefined)).toBe(DEFAULT_COLLAPSE_THRESHOLD);
+  });
+
+  it('returns the default threshold for empty input', () => {
+    expect(parseCollapseThreshold('')).toBe(DEFAULT_COLLAPSE_THRESHOLD);
+    expect(parseCollapseThreshold('   ')).toBe(DEFAULT_COLLAPSE_THRESHOLD);
+  });
+
+  it('parses a normal integer threshold', () => {
+    expect(parseCollapseThreshold('5')).toBe(5);
+    expect(parseCollapseThreshold('12')).toBe(12);
+  });
+
+  it('allows zero', () => {
+    expect(parseCollapseThreshold('0')).toBe(0);
+  });
+
+  it('rejects negative thresholds', () => {
+    expect(() => parseCollapseThreshold('-1')).toThrow(
+      'Invalid collapse-threshold input: "-1". Expected a non-negative integer.',
+    );
+  });
+
+  it('rejects decimal thresholds', () => {
+    expect(() => parseCollapseThreshold('3.5')).toThrow(
+      'Invalid collapse-threshold input: "3.5". Expected a non-negative integer.',
+    );
+  });
+
+  it('rejects non-numeric thresholds', () => {
+    expect(() => parseCollapseThreshold('five')).toThrow(
+      'Invalid collapse-threshold input: "five". Expected a non-negative integer.',
+    );
+  });
+});

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -26,19 +26,25 @@ describe('parseCollapseThreshold', () => {
 
   it('rejects negative thresholds', () => {
     expect(() => parseCollapseThreshold('-1')).toThrow(
-      'Invalid collapse-threshold input: "-1". Expected a non-negative integer.',
+      'Invalid collapse-threshold input: "-1". Expected a non-negative safe integer.',
     );
   });
 
   it('rejects decimal thresholds', () => {
     expect(() => parseCollapseThreshold('3.5')).toThrow(
-      'Invalid collapse-threshold input: "3.5". Expected a non-negative integer.',
+      'Invalid collapse-threshold input: "3.5". Expected a non-negative safe integer.',
     );
   });
 
   it('rejects non-numeric thresholds', () => {
     expect(() => parseCollapseThreshold('five')).toThrow(
-      'Invalid collapse-threshold input: "five". Expected a non-negative integer.',
+      'Invalid collapse-threshold input: "five". Expected a non-negative safe integer.',
+    );
+  });
+
+  it('rejects thresholds above Number.MAX_SAFE_INTEGER', () => {
+    expect(() => parseCollapseThreshold('9007199254740993')).toThrow(
+      'Invalid collapse-threshold input: "9007199254740993". Expected a non-negative safe integer.',
     );
   });
 });

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,4 +1,12 @@
 export const DEFAULT_COLLAPSE_THRESHOLD = 5;
+const COLLAPSE_THRESHOLD_ERROR_SUFFIX =
+  'Expected a non-negative safe integer.';
+
+function createCollapseThresholdError(rawInput: string | undefined): Error {
+  return new Error(
+    `Invalid collapse-threshold input: "${rawInput}". ${COLLAPSE_THRESHOLD_ERROR_SUFFIX}`,
+  );
+}
 
 export function parseCollapseThreshold(rawInput: string | undefined): number {
   const normalizedInput = rawInput?.trim();
@@ -8,17 +16,13 @@ export function parseCollapseThreshold(rawInput: string | undefined): number {
   }
 
   if (!/^\d+$/.test(normalizedInput)) {
-    throw new Error(
-      `Invalid collapse-threshold input: "${rawInput}". Expected a non-negative integer.`,
-    );
+    throw createCollapseThresholdError(rawInput);
   }
 
   const value = Number.parseInt(normalizedInput, 10);
 
   if (!Number.isSafeInteger(value)) {
-    throw new Error(
-      `Invalid collapse-threshold input: "${rawInput}". Expected a non-negative integer.`,
-    );
+    throw createCollapseThresholdError(rawInput);
   }
 
   return value;

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,0 +1,25 @@
+export const DEFAULT_COLLAPSE_THRESHOLD = 5;
+
+export function parseCollapseThreshold(rawInput: string | undefined): number {
+  const normalizedInput = rawInput?.trim();
+
+  if (!normalizedInput) {
+    return DEFAULT_COLLAPSE_THRESHOLD;
+  }
+
+  if (!/^\d+$/.test(normalizedInput)) {
+    throw new Error(
+      `Invalid collapse-threshold input: "${rawInput}". Expected a non-negative integer.`,
+    );
+  }
+
+  const value = Number.parseInt(normalizedInput, 10);
+
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(
+      `Invalid collapse-threshold input: "${rawInput}". Expected a non-negative integer.`,
+    );
+  }
+
+  return value;
+}


### PR DESCRIPTION
This adds explicit validation for the `collapse-threshold` input instead of relying on `parseInt` and whatever value falls out.

Empty input still uses the default. `0` is allowed. Negative values, decimals, and non-numeric input now fail clearly with an error message instead of silently producing confusing behavior.