### PR TITLE
add more verification to release workflow handoff

### DIFF
--- a/.github/workflows/publish-verified-release.yml
+++ b/.github/workflows/publish-verified-release.yml
@@ -5,6 +5,7 @@ on:
     types: [publish_verified_release]
 
 permissions:
+  actions: read
   contents: write
   attestations: read
 
@@ -26,6 +27,7 @@ jobs:
           TAG: ${{ github.event.client_payload.tag }}
           VERIFIED_REF: ${{ github.event.client_payload.verified_ref }}
           VERIFIED_RUN_ID: ${{ github.event.client_payload.verified_run_id }}
+          VERIFIED_SHA: ${{ github.event.client_payload.verified_sha }}
         run: |
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Expected semver release tag in repository_dispatch payload, got: $TAG"
@@ -43,7 +45,46 @@ jobs:
             exit 1
           fi
 
+          if [[ ! "$VERIFIED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Missing or invalid verified_sha in repository_dispatch payload."
+            exit 1
+          fi
+
           echo "Publishing $TAG after verification run ${VERIFIED_RUN_ID}."
+
+          run_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_RUN_ID}")"
+
+          run_name="$(jq -r '.name // empty' <<<"$run_json")"
+          run_event="$(jq -r '.event // empty' <<<"$run_json")"
+          run_status="$(jq -r '.status // empty' <<<"$run_json")"
+          run_conclusion="$(jq -r '.conclusion // empty' <<<"$run_json")"
+          run_head_branch="$(jq -r '.head_branch // empty' <<<"$run_json")"
+          run_head_sha="$(jq -r '.head_sha // empty' <<<"$run_json")"
+
+          if [[ "$run_name" != "Verify Draft Release" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} is ${run_name:-unnamed}, not Verify Draft Release."
+            exit 1
+          fi
+
+          if [[ "$run_event" != "workflow_dispatch" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} was triggered by ${run_event:-unknown}, not workflow_dispatch."
+            exit 1
+          fi
+
+          if [[ "$run_status" != "completed" || "$run_conclusion" != "success" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} is ${run_status:-unknown}/${run_conclusion:-unknown}, not completed/success."
+            exit 1
+          fi
+
+          if [[ "$run_head_branch" != "$TAG" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} was recorded on ${run_head_branch:-unknown}, not ${TAG}."
+            exit 1
+          fi
+
+          if [[ "$run_head_sha" != "$VERIFIED_SHA" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} head SHA ${run_head_sha:-unknown} does not match verified SHA ${VERIFIED_SHA}."
+            exit 1
+          fi
 
           git fetch --no-tags origin main:refs/remotes/origin/main
 
@@ -59,6 +100,11 @@ jobs:
           head_commit="$(git rev-parse HEAD)"
           if [[ "$tag_commit" != "$head_commit" ]]; then
             echo "Expected checked out commit $head_commit to match $TAG commit $tag_commit."
+            exit 1
+          fi
+
+          if [[ "$tag_commit" != "$VERIFIED_SHA" ]]; then
+            echo "Expected checked out tag commit $tag_commit to match verified SHA $VERIFIED_SHA."
             exit 1
           fi
 

--- a/.github/workflows/verify-draft-release.yml
+++ b/.github/workflows/verify-draft-release.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: automation
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      verified_ref: ${{ steps.meta.outputs.verified_ref }}
+      verified_run_id: ${{ steps.meta.outputs.verified_run_id }}
+      verified_sha: ${{ steps.meta.outputs.verified_sha }}
     steps:
       - name: Validate release tag input and workflow ref
         env:
@@ -35,6 +40,21 @@ jobs:
             echo "In the GitHub UI, choose $TAG in the Run workflow branch/tag dropdown."
             exit 1
           fi
+
+      - name: Record verified release metadata
+        id: meta
+        env:
+          TAG: ${{ inputs.tag }}
+          VERIFIED_REF: ${{ github.ref }}
+          VERIFIED_RUN_ID: ${{ github.run_id }}
+          VERIFIED_SHA: ${{ github.sha }}
+        run: |
+          {
+            echo "tag=$TAG"
+            echo "verified_ref=$VERIFIED_REF"
+            echo "verified_run_id=$VERIFIED_RUN_ID"
+            echo "verified_sha=$VERIFIED_SHA"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -151,11 +171,15 @@ jobs:
       - name: Dispatch the publish workflow
         env:
           GH_TOKEN: ${{ secrets.IAM_UPDATE_PAT }}
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERIFIED_REF: ${{ steps.meta.outputs.verified_ref }}
+          VERIFIED_RUN_ID: ${{ steps.meta.outputs.verified_run_id }}
+          VERIFIED_SHA: ${{ steps.meta.outputs.verified_sha }}
         run: |
           gh api "repos/${{ github.repository }}/dispatches" \
             --method POST \
             -f event_type='publish_verified_release' \
             --field "client_payload[tag]=$TAG" \
-            --field "client_payload[verified_ref]=${GITHUB_REF}" \
-            --field "client_payload[verified_run_id]=${GITHUB_RUN_ID}"
+            --field "client_payload[verified_ref]=$VERIFIED_REF" \
+            --field "client_payload[verified_run_id]=$VERIFIED_RUN_ID" \
+            --field "client_payload[verified_sha]=$VERIFIED_SHA"


### PR DESCRIPTION
Verify draft release workflow now sends the verified commit SHA along with the tag, ref, and run id.
Publish Verified Release now checks that the referenced Actions run is the successful Verify Draft Release run for that same tag and commit before it publishes anything.