### PR TITLE
fix release workflow sequencing

### DIFF
--- a/.github/workflows/publish-verified-release.yml
+++ b/.github/workflows/publish-verified-release.yml
@@ -52,12 +52,25 @@ jobs:
 
           echo "Publishing $TAG after verification run ${VERIFIED_RUN_ID}."
 
-          run_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_RUN_ID}")"
+          run_status=''
+          run_conclusion=''
+          for attempt in {1..30}; do
+            run_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_RUN_ID}")"
+            run_status="$(jq -r '.status // empty' <<<"$run_json")"
+            run_conclusion="$(jq -r '.conclusion // empty' <<<"$run_json")"
+
+            if [[ "$run_status" == "completed" ]]; then
+              break
+            fi
+
+            if [[ "$attempt" -lt 30 ]]; then
+              echo "Verification run ${VERIFIED_RUN_ID} is ${run_status:-unknown}; waiting for completion."
+              sleep 2
+            fi
+          done
 
           run_name="$(jq -r '.name // empty' <<<"$run_json")"
           run_event="$(jq -r '.event // empty' <<<"$run_json")"
-          run_status="$(jq -r '.status // empty' <<<"$run_json")"
-          run_conclusion="$(jq -r '.conclusion // empty' <<<"$run_json")"
           run_head_branch="$(jq -r '.head_branch // empty' <<<"$run_json")"
           run_head_sha="$(jq -r '.head_sha // empty' <<<"$run_json")"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Wait for the draft-release verification workflow to finish before publishing the release
+- Move the signed major tag only after the release is published, verified, and immutable
+
 ## [1.2.6] - 2026-05-14
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,15 +72,12 @@ Release bundles are generated on Ubuntu through GitHub Actions rather than being
 
 4. Review and merge the resulting `release-candidate/$TAG` pull request.
 
-5. After that PR is merged, create and push the signed release tag and the movable major tag:
+5. After that PR is merged, create and push the signed release tag:
 
    ```bash
-   old_major_tag="$(git ls-remote --refs --tags origin "refs/tags/$MAJOR_TAG" | awk '{print $1}')"
    git fetch origin main --tags
    git tag -s "$TAG" origin/main -m "$TAG"
-   git tag -s -f "$MAJOR_TAG" origin/main -m "$MAJOR_TAG"
    git push origin "refs/tags/$TAG"
-   git push --force-with-lease="refs/tags/$MAJOR_TAG:$old_major_tag" origin "refs/tags/$MAJOR_TAG"
    ```
 
 6. Create the draft GitHub release:
@@ -107,11 +104,19 @@ Release bundles are generated on Ubuntu through GitHub Actions rather than being
    gh release view "$TAG" --json isDraft,isImmutable,isPrerelease,tagName,targetCommitish,url
    ```
 
-9. Run the local verification script at the end:
+9. Run the local verification script:
 
    ```bash
    ./verify-release.sh --tag "$TAG"
    ```
+
+10. After publication and verification succeed, move the signed major tag to the release commit:
+
+    ```bash
+    old_major_tag="$(git ls-remote --refs --tags origin "refs/tags/$MAJOR_TAG" | awk '{print $1}')"
+    git tag -s -f "$MAJOR_TAG" "$TAG^{commit}" -m "$MAJOR_TAG"
+    git push --force-with-lease="refs/tags/$MAJOR_TAG:$old_major_tag" origin "refs/tags/$MAJOR_TAG"
+    ```
 
 If you need the keys, import them
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Published releases are prepared and verified in GitHub Actions on Ubuntu.
 1. Run the `Verify Draft Release` workflow with that tag.
 1. If verification succeeds, the workflow will generate an OIDC-backed attestation for
    `dist/index.js` and publish the draft release.
+1. After publication is confirmed immutable, move the signed major tag (for example, `v1`) to the release commit.
 
 ## How It Works
 


### PR DESCRIPTION
1. wait for draft-release verification to complete before publishing
1. move the signed major tag only after immutable publication and local verification
1. align the README, contributing guide, and changelog with the corrected sequence.