### PR TITLE
Prepare v1.2.7 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expand-aws-iam-wildcards",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expand-aws-iam-wildcards",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expand-aws-iam-wildcards",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "packageManager": "npm@10.8.0",
   "description": "GitHub Action to expand IAM wildcard actions in PR comments",
   "type": "module",


### PR DESCRIPTION
Generates the release bundle on Ubuntu, updates package metadata for v1.2.7, and prepares the exact commit that should be signed and tagged for release.