### PR TITLE
fix release verification

### DIFF
--- a/.github/workflows/publish-verified-release.yml
+++ b/.github/workflows/publish-verified-release.yml
@@ -74,8 +74,9 @@ jobs:
           run_head_branch="$(jq -r '.head_branch // empty' <<<"$run_json")"
           run_head_sha="$(jq -r '.head_sha // empty' <<<"$run_json")"
 
-          if [[ "$run_name" != "Verify Draft Release" ]]; then
-            echo "Workflow run ${VERIFIED_RUN_ID} is ${run_name:-unnamed}, not Verify Draft Release."
+          expected_run_name="Verify ${TAG}"
+          if [[ "$run_name" != "$expected_run_name" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} is ${run_name:-unnamed}, not ${expected_run_name}."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Accept release-specific verify workflow run names before publishing a verified release
+
 ## [1.2.7] - 2026-07-03
 
 ### Fixed


### PR DESCRIPTION
The publish workflow still expected the old static run name `Verify Draft Release`,  after the run-name change, the actual run name is: `Verify v1.2.7`