### PR TITLE
release script prepts changelog for release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,6 +8,11 @@ on:
         description: Semver release version without a leading v
         required: true
         type: string
+      finalize_changelog:
+        description: Finalize CHANGELOG.md with the requested release version
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -49,6 +54,12 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Finalize changelog
+        if: inputs.finalize_changelog
+        env:
+          VERSION: ${{ inputs.version }}
+        run: scripts/release.sh "$VERSION" --finalize-changelog
+
       - name: Lint Markdown
         run: npm run lint:md
 
@@ -75,7 +86,7 @@ jobs:
           git switch -c "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json dist/index.js
+          git add CHANGELOG.md package.json package-lock.json dist/index.js
 
           if git diff --cached --quiet; then
             echo "No release preparation changes were generated."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accept release-specific verify workflow run names before publishing a verified release
 - Add a release script continuation mode for tagging, publishing, verifying, and moving the major tag
 - Make the default release script flow wait for PR review and then continue the release
+- Finalize changelog headings and compare links during release preparation
+- Make changelog finalization the default release script behavior with an opt-out flag
 
 ## [1.2.7] - 2026-07-03
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ prepare workflow.
    test -z "$(git status --porcelain)"
    test -n "$(git config --get user.signingkey)"
    gpg --list-secret-keys "$(git config --get user.signingkey)"
-   grep -q "^## \\[$VERSION\\]" CHANGELOG.md
+   grep -q "^## \\[UNRELEASED\\]" CHANGELOG.md
    ! git rev-parse -q --verify "refs/tags/$TAG"
    ! git ls-remote --exit-code --tags origin "$TAG"
    ! git ls-remote --exit-code --heads origin "$BRANCH"
@@ -84,9 +84,15 @@ prepare workflow.
 
    Instead of running the preflight checks and `Prepare Release` commands manually, use the release script. It waits
    after the release preparation PR is ready for review; after you merge that PR, press Enter to continue the release.
+   By default, the release preparation PR finalizes the changelog with the requested version, date, and compare links.
+   If the changelog was already finalized manually, pass `--no-finalize-changelog`.
 
    ```bash
    scripts/release.sh "$VERSION"
+   ```
+
+   ```bash
+   scripts/release.sh "$VERSION" --no-finalize-changelog
    ```
 
 3. Run `Prepare Release` from `main`:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,14 +6,19 @@ usage() {
 Usage:
   scripts/release.sh VERSION
   scripts/release.sh VERSION --continue
+  scripts/release.sh VERSION --no-finalize-changelog
+  scripts/release.sh VERSION --finalize-changelog
 
 Examples:
   scripts/release.sh 1.2.8
   scripts/release.sh 1.2.8 --continue
+  scripts/release.sh 1.2.8 --no-finalize-changelog
 
-Without --continue, prepares a release candidate PR and waits for review.
+Without --continue, prepares a release candidate PR, finalizes CHANGELOG.md, and waits for review.
 After you merge that PR, press Enter and the script completes the release.
 With --continue, resumes after the release candidate PR is already merged.
+With --no-finalize-changelog, expects CHANGELOG.md to already have the release heading and links.
+With --finalize-changelog, updates CHANGELOG.md for the release preparation PR.
 EOF
 }
 
@@ -78,6 +83,64 @@ require_signing_key() {
   fi
 
   gpg --list-secret-keys "$signing_key" >/dev/null
+}
+
+finalize_changelog() {
+  node - "$VERSION" <<'NODE'
+const fs = require('fs');
+
+const version = process.argv[2];
+const repoUrl = 'https://github.com/thekbb/expand-aws-iam-wildcards';
+const date = process.env.RELEASE_DATE || new Date().toISOString().slice(0, 10);
+const tag = `v${version}`;
+const changelogPath = 'CHANGELOG.md';
+let changelog = fs.readFileSync(changelogPath, 'utf8');
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+if (!/^## \[UNRELEASED\]$/m.test(changelog)) {
+  fail('CHANGELOG.md is missing an [UNRELEASED] heading');
+}
+
+const versionHeadingPattern = new RegExp(`^## \\[${escapeRegExp(version)}\\](?:\\s|-|$)`, 'm');
+if (versionHeadingPattern.test(changelog)) {
+  fail(`CHANGELOG.md already has a ${version} heading`);
+}
+
+const versionLinkPattern = new RegExp(`^\\[${escapeRegExp(version)}\\]:\\s`, 'm');
+if (versionLinkPattern.test(changelog)) {
+  fail(`CHANGELOG.md already has a ${version} link`);
+}
+
+const unreleasedLinkPattern = new RegExp(
+  `^\\[Unreleased\\]: ${escapeRegExp(repoUrl)}/compare/v([0-9]+\\.[0-9]+\\.[0-9]+)\\.\\.\\.HEAD$`,
+  'm',
+);
+const unreleasedLink = changelog.match(unreleasedLinkPattern);
+if (!unreleasedLink) {
+  fail('CHANGELOG.md is missing the expected [Unreleased] compare link');
+}
+
+const previousVersion = unreleasedLink[1];
+changelog = changelog.replace(
+  /^## \[UNRELEASED\]\n/m,
+  `## [UNRELEASED]\n\n## [${version}] - ${date}\n`,
+);
+
+changelog = changelog.replace(
+  unreleasedLinkPattern,
+  `[Unreleased]: ${repoUrl}/compare/${tag}...HEAD\n[${version}]: ${repoUrl}/compare/v${previousVersion}...${tag}`,
+);
+
+fs.writeFileSync(changelogPath, changelog);
+NODE
 }
 
 find_new_workflow_run() {
@@ -156,7 +219,12 @@ prepare_release() {
   require_clean_main
   require_signing_key
 
-  grep -q "^## \\[$VERSION\\]" CHANGELOG.md || die "CHANGELOG.md is missing an entry for $VERSION"
+  if [[ "$FINALIZE_CHANGELOG" == "true" ]]; then
+    grep -q "^## \\[UNRELEASED\\]" CHANGELOG.md || die "CHANGELOG.md is missing an [UNRELEASED] entry"
+  else
+    grep -q "^## \\[$VERSION\\] - " CHANGELOG.md || die "CHANGELOG.md is missing a dated $VERSION entry"
+    grep -q "^\\[$VERSION\\]: .*v${VERSION}$" CHANGELOG.md || die "CHANGELOG.md is missing the $VERSION compare link"
+  fi
 
   if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
     die "local tag already exists: $TAG"
@@ -173,7 +241,7 @@ prepare_release() {
   echo "Dispatching Prepare Release for $TAG"
 
   previous_run_id="$(latest_workflow_run_id prepare-release.yml "$PREPARE_RUN_NAME")"
-  gh workflow run prepare-release.yml -f version="$VERSION"
+  gh workflow run prepare-release.yml -f version="$VERSION" -f finalize_changelog="$FINALIZE_CHANGELOG"
   run_id="$(find_new_workflow_run prepare-release.yml "$PREPARE_RUN_NAME" "$previous_run_id")" \
     || die "could not find the newly dispatched Prepare Release workflow run"
 
@@ -319,6 +387,7 @@ continue_release() {
   local release_sha
   local package_version
   local lockfile_version
+  local changelog
 
   echo "Continuing release for $TAG"
 
@@ -354,6 +423,15 @@ continue_release() {
     die "package-lock.json at $release_sha has version $lockfile_version, expected $VERSION"
   fi
 
+  changelog="$(git show "$release_sha:CHANGELOG.md")"
+  if ! grep -q "^## \\[$VERSION\\] - " <<<"$changelog"; then
+    die "CHANGELOG.md at $release_sha is missing a dated $VERSION heading"
+  fi
+
+  if ! grep -q "^\\[$VERSION\\]: .*v${VERSION}$" <<<"$changelog"; then
+    die "CHANGELOG.md at $release_sha is missing the $VERSION compare link"
+  fi
+
   ensure_version_tag "$release_sha"
   ensure_draft_release
   verify_and_publish_release
@@ -376,19 +454,35 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+if [[ "$#" -lt 1 || "$#" -gt 3 ]]; then
   usage >&2
   exit 2
 fi
 
 VERSION=$1
 MODE=prepare
+FINALIZE_CHANGELOG=true
 
-if [[ "${2:-}" == "--continue" ]]; then
-  MODE=post_merge
-elif [[ -n "${2:-}" ]]; then
-  usage >&2
-  exit 2
+for arg in "${@:2}"; do
+  case "$arg" in
+    --continue)
+      MODE=post_merge
+      ;;
+    --finalize-changelog)
+      MODE=finalize_changelog
+      ;;
+    --no-finalize-changelog)
+      FINALIZE_CHANGELOG=false
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$MODE" != "prepare" && "$FINALIZE_CHANGELOG" == "false" ]]; then
+  die "--no-finalize-changelog is only valid for the default release preparation mode"
 fi
 
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -398,16 +492,22 @@ fi
 TAG="v$VERSION"
 MAJOR_TAG="v${VERSION%%.*}"
 BRANCH="release-candidate/$TAG"
-PREPARE_RUN_NAME="Prepare $TAG"
-VERIFY_RUN_NAME="Verify $TAG"
-
 require_command awk
-require_command gh
 require_command git
-require_command gpg
 require_command grep
 require_command head
 require_command node
+
+if [[ "$MODE" == "finalize_changelog" ]]; then
+  finalize_changelog
+  exit 0
+fi
+
+PREPARE_RUN_NAME="Prepare $TAG"
+VERIFY_RUN_NAME="Verify $TAG"
+
+require_command gh
+require_command gpg
 
 if [[ "$MODE" == "post_merge" ]]; then
   continue_release


### PR DESCRIPTION
the release script adds the version passed in as the heading, and the link.

`--no-finalize-changelog` can be passed in if the `CHANGELOG` is already set - or used with `--continue`