### PR TITLE
Move changelog release prep to TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Move changelog release preparation into tested TypeScript
+
 ## [1.3.0] - 2026-07-06
 
 ### Changed

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        target: 90%

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -86,61 +89,13 @@ require_signing_key() {
 }
 
 finalize_changelog() {
-  node - "$VERSION" <<'NODE'
-const fs = require('fs');
+  local tsx_loader="$REPO_ROOT/node_modules/tsx/dist/loader.mjs"
 
-const version = process.argv[2];
-const repoUrl = 'https://github.com/thekbb/expand-aws-iam-wildcards';
-const date = process.env.RELEASE_DATE || new Date().toISOString().slice(0, 10);
-const tag = `v${version}`;
-const changelogPath = 'CHANGELOG.md';
-let changelog = fs.readFileSync(changelogPath, 'utf8');
+  if [[ ! -f "$tsx_loader" ]]; then
+    die "tsx is not installed; run npm install first"
+  fi
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function fail(message) {
-  console.error(`error: ${message}`);
-  process.exit(1);
-}
-
-if (!/^## \[UNRELEASED\]$/m.test(changelog)) {
-  fail('CHANGELOG.md is missing an [UNRELEASED] heading');
-}
-
-const versionHeadingPattern = new RegExp(`^## \\[${escapeRegExp(version)}\\](?:\\s|-|$)`, 'm');
-if (versionHeadingPattern.test(changelog)) {
-  fail(`CHANGELOG.md already has a ${version} heading`);
-}
-
-const versionLinkPattern = new RegExp(`^\\[${escapeRegExp(version)}\\]:\\s`, 'm');
-if (versionLinkPattern.test(changelog)) {
-  fail(`CHANGELOG.md already has a ${version} link`);
-}
-
-const unreleasedLinkPattern = new RegExp(
-  `^\\[Unreleased\\]: ${escapeRegExp(repoUrl)}/compare/v([0-9]+\\.[0-9]+\\.[0-9]+)\\.\\.\\.HEAD$`,
-  'm',
-);
-const unreleasedLink = changelog.match(unreleasedLinkPattern);
-if (!unreleasedLink) {
-  fail('CHANGELOG.md is missing the expected [Unreleased] compare link');
-}
-
-const previousVersion = unreleasedLink[1];
-changelog = changelog.replace(
-  /^## \[UNRELEASED\]\n/m,
-  `## [UNRELEASED]\n\n## [${version}] - ${date}\n`,
-);
-
-changelog = changelog.replace(
-  unreleasedLinkPattern,
-  `[Unreleased]: ${repoUrl}/compare/${tag}...HEAD\n[${version}]: ${repoUrl}/compare/v${previousVersion}...${tag}`,
-);
-
-fs.writeFileSync(changelogPath, changelog);
-NODE
+  node --import "$tsx_loader" "$SCRIPT_DIR/release/changelog.ts" "$VERSION"
 }
 
 find_new_workflow_run() {

--- a/scripts/release/changelog.test.ts
+++ b/scripts/release/changelog.test.ts
@@ -1,6 +1,13 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { finalizeChangelogContent } from './changelog.js';
+import {
+  finalizeChangelogContent,
+  finalizeChangelogFile,
+  runFinalizeChangelogCli,
+} from './changelog.js';
 
 const baseChangelog = `# Changelog
 
@@ -92,5 +99,73 @@ describe('finalizeChangelogContent', () => {
         },
       ),
     ).toThrow('CHANGELOG.md is missing the expected [Unreleased] compare link');
+  });
+});
+
+describe('finalizeChangelogFile', () => {
+  it('updates a changelog file in place', () => {
+    const changelogPath = join(mkdtempSync(join(tmpdir(), 'release-changelog-')), 'CHANGELOG.md');
+    writeFileSync(changelogPath, baseChangelog);
+
+    finalizeChangelogFile(changelogPath, {
+      date: '2026-07-06',
+      version: '1.3.0',
+    });
+
+    expect(readFileSync(changelogPath, 'utf8')).toContain('## [1.3.0] - 2026-07-06');
+  });
+});
+
+describe('runFinalizeChangelogCli', () => {
+  it('finalizes CHANGELOG.md in the current working directory', () => {
+    const previousCwd = process.cwd();
+    const workspace = mkdtempSync(join(tmpdir(), 'release-changelog-cli-'));
+    writeFileSync(join(workspace, 'CHANGELOG.md'), baseChangelog);
+
+    process.chdir(workspace);
+    try {
+      const exitCode = runFinalizeChangelogCli({
+        argv: ['node', 'changelog.ts', '1.3.0'],
+        env: { RELEASE_DATE: '2026-07-06' },
+        stderr: console,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(readFileSync('CHANGELOG.md', 'utf8')).toContain('## [1.3.0] - 2026-07-06');
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('rejects a missing version argument', () => {
+    const errors: string[] = [];
+
+    const exitCode = runFinalizeChangelogCli({
+      argv: ['node', 'changelog.ts'],
+      env: {},
+      stderr: { error: (message: string) => errors.push(message) },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors).toEqual(['error: expected version input like 1.2.3']);
+  });
+
+  it('reports changelog finalization errors', () => {
+    const errors: string[] = [];
+    const previousCwd = process.cwd();
+
+    process.chdir(mkdtempSync(join(tmpdir(), 'release-changelog-empty-')));
+    try {
+      const exitCode = runFinalizeChangelogCli({
+        argv: ['node', 'changelog.ts', '1.3.0'],
+        env: { RELEASE_DATE: '2026-07-06' },
+        stderr: { error: (message: string) => errors.push(message) },
+      });
+
+      expect(exitCode).toBe(1);
+      expect(errors).toEqual(['error: ENOENT: no such file or directory, open \'CHANGELOG.md\'']);
+    } finally {
+      process.chdir(previousCwd);
+    }
   });
 });

--- a/scripts/release/changelog.test.ts
+++ b/scripts/release/changelog.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { finalizeChangelogContent } from './changelog.js';
+
+const baseChangelog = `# Changelog
+
+## [UNRELEASED]
+
+### Fixed
+
+- Fix release automation
+- Keep publish checks strict
+
+## [1.2.7] - 2026-07-03
+
+### Fixed
+
+- Previous release
+
+[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.2.7...HEAD
+[1.2.7]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.2.6...v1.2.7
+`;
+
+describe('finalizeChangelogContent', () => {
+  it('moves unreleased notes under a dated release heading', () => {
+    const result = finalizeChangelogContent(baseChangelog, {
+      date: '2026-07-06',
+      version: '1.3.0',
+    });
+
+    expect(result).toContain(`## [UNRELEASED]
+
+## [1.3.0] - 2026-07-06
+
+### Fixed
+
+- Fix release automation
+- Keep publish checks strict`);
+  });
+
+  it('updates the unreleased link and adds the release compare link', () => {
+    const result = finalizeChangelogContent(baseChangelog, {
+      date: '2026-07-06',
+      version: '1.3.0',
+    });
+
+    expect(result).toContain(
+      '[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.3.0...HEAD',
+    );
+    expect(result).toContain(
+      '[1.3.0]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.2.7...v1.3.0',
+    );
+  });
+
+  it('rejects a changelog without an unreleased heading', () => {
+    expect(() =>
+      finalizeChangelogContent(baseChangelog.replace('## [UNRELEASED]\n', ''), {
+        date: '2026-07-06',
+        version: '1.3.0',
+      }),
+    ).toThrow('CHANGELOG.md is missing an [UNRELEASED] heading');
+  });
+
+  it('rejects a changelog that already has the release heading', () => {
+    expect(() =>
+      finalizeChangelogContent(`${baseChangelog}\n## [1.3.0] - 2026-07-06\n`, {
+        date: '2026-07-06',
+        version: '1.3.0',
+      }),
+    ).toThrow('CHANGELOG.md already has a 1.3.0 heading');
+  });
+
+  it('rejects a changelog that already has the release link', () => {
+    expect(() =>
+      finalizeChangelogContent(`${baseChangelog}\n[1.3.0]: https://example.com\n`, {
+        date: '2026-07-06',
+        version: '1.3.0',
+      }),
+    ).toThrow('CHANGELOG.md already has a 1.3.0 link');
+  });
+
+  it('rejects a changelog without the expected unreleased compare link', () => {
+    expect(() =>
+      finalizeChangelogContent(
+        baseChangelog.replace(
+          '[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.2.7...HEAD',
+          '[Unreleased]: https://example.com',
+        ),
+        {
+          date: '2026-07-06',
+          version: '1.3.0',
+        },
+      ),
+    ).toThrow('CHANGELOG.md is missing the expected [Unreleased] compare link');
+  });
+});

--- a/scripts/release/changelog.ts
+++ b/scripts/release/changelog.ts
@@ -62,25 +62,42 @@ export function finalizeChangelogFile(
   writeFileSync(changelogPath, finalizeChangelogContent(changelog, options));
 }
 
-function main(): void {
-  const version = process.argv[2];
+export interface FinalizeChangelogCliOptions {
+  argv: readonly string[];
+  env: NodeJS.ProcessEnv;
+  stderr: Pick<typeof console, 'error'>;
+}
+
+export function runFinalizeChangelogCli({
+  argv,
+  env,
+  stderr,
+}: FinalizeChangelogCliOptions): number {
+  const version = argv[2];
   if (version === undefined || version === '') {
-    console.error('error: expected version input like 1.2.3');
-    process.exit(1);
+    stderr.error('error: expected version input like 1.2.3');
+    return 1;
   }
 
   try {
     finalizeChangelogFile('CHANGELOG.md', {
-      date: process.env.RELEASE_DATE ?? new Date().toISOString().slice(0, 10),
+      date: env.RELEASE_DATE ?? new Date().toISOString().slice(0, 10),
       version,
     });
+    return 0;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`error: ${message}`);
-    process.exit(1);
+    stderr.error(`error: ${message}`);
+    return 1;
   }
 }
 
+/* c8 ignore next 3 */
+function main(): void {
+  process.exit(runFinalizeChangelogCli({ argv: process.argv, env: process.env, stderr: console }));
+}
+
+/* c8 ignore next 3 */
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main();
 }

--- a/scripts/release/changelog.ts
+++ b/scripts/release/changelog.ts
@@ -1,0 +1,86 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_REPO_URL = 'https://github.com/thekbb/expand-aws-iam-wildcards';
+
+export interface FinalizeChangelogOptions {
+  date: string;
+  repoUrl?: string;
+  version: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function finalizeChangelogContent(
+  changelog: string,
+  { date, repoUrl = DEFAULT_REPO_URL, version }: FinalizeChangelogOptions,
+): string {
+  if (!/^## \[UNRELEASED\]$/m.test(changelog)) {
+    throw new Error('CHANGELOG.md is missing an [UNRELEASED] heading');
+  }
+
+  const versionHeadingPattern = new RegExp(
+    `^## \\[${escapeRegExp(version)}\\](?:\\s|-|$)`,
+    'm',
+  );
+  if (versionHeadingPattern.test(changelog)) {
+    throw new Error(`CHANGELOG.md already has a ${version} heading`);
+  }
+
+  const versionLinkPattern = new RegExp(`^\\[${escapeRegExp(version)}\\]:\\s`, 'm');
+  if (versionLinkPattern.test(changelog)) {
+    throw new Error(`CHANGELOG.md already has a ${version} link`);
+  }
+
+  const unreleasedLinkPattern = new RegExp(
+    `^\\[Unreleased\\]: ${escapeRegExp(repoUrl)}/compare/v([0-9]+\\.[0-9]+\\.[0-9]+)\\.\\.\\.HEAD$`,
+    'm',
+  );
+  const unreleasedLink = changelog.match(unreleasedLinkPattern);
+  if (unreleasedLink?.[1] === undefined) {
+    throw new Error('CHANGELOG.md is missing the expected [Unreleased] compare link');
+  }
+
+  const previousVersion = unreleasedLink[1];
+  const tag = `v${version}`;
+
+  return changelog
+    .replace(/^## \[UNRELEASED\]\n/m, `## [UNRELEASED]\n\n## [${version}] - ${date}\n`)
+    .replace(
+      unreleasedLinkPattern,
+      `[Unreleased]: ${repoUrl}/compare/${tag}...HEAD\n[${version}]: ${repoUrl}/compare/v${previousVersion}...${tag}`,
+    );
+}
+
+export function finalizeChangelogFile(
+  changelogPath: string,
+  options: FinalizeChangelogOptions,
+): void {
+  const changelog = readFileSync(changelogPath, 'utf8');
+  writeFileSync(changelogPath, finalizeChangelogContent(changelog, options));
+}
+
+function main(): void {
+  const version = process.argv[2];
+  if (version === undefined || version === '') {
+    console.error('error: expected version input like 1.2.3');
+    process.exit(1);
+  }
+
+  try {
+    finalizeChangelogFile('CHANGELOG.md', {
+      date: process.env.RELEASE_DATE ?? new Date().toISOString().slice(0, 10),
+      version,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`error: ${message}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,15 +3,16 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/release/**/*.test.ts'],
     pool: 'forks',
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
       provider: 'v8',
-      include: ['src/**/*.ts'],
+      include: ['src/**/*.ts', 'scripts/release/**/*.ts'],
       exclude: [
         'src/**/*.test.ts',
+        'scripts/release/**/*.test.ts',
         'src/iam-actions.ts',
         'src/index.ts',
         'src/types.ts',


### PR DESCRIPTION
* add tested TypeScript changelog release prep
* Keep the existing release script entrypoint
* use the TypeScript changelog updater from release prep.