### PR TITLE
dependabot should always update all codeql actions in same pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,10 @@ updates:
       default-days: 7
     commit-message:
       prefix: "ci"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "pre-commit"
     directory: "/"


### PR DESCRIPTION
THis will prevent what happened with #132 and #133 by always having dependabot update all codeql modules in one PR.