### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [1.4.0] - 2026-07-21
+
 ### Changed
 
 - Move changelog release preparation into tested TypeScript
@@ -245,7 +247,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial release
 
 <!-- markdownlint-disable-next-line MD053 -->
-[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.2.7...v1.3.0
 [1.2.7]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.2.5...v1.2.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expand-aws-iam-wildcards",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expand-aws-iam-wildcards",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expand-aws-iam-wildcards",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "packageManager": "npm@10.8.0",
   "description": "GitHub Action to expand IAM wildcard actions in PR comments",
   "type": "module",


### PR DESCRIPTION
Generates the release bundle on Ubuntu, updates package metadata for v1.4.0, and prepares the exact commit that should be signed and tagged for release.