### PR TITLE
Add runtime compatibility fixtures

### DIFF
--- a/fixtures/compatibility/README.md
+++ b/fixtures/compatibility/README.md
@@ -1,0 +1,9 @@
+# Runtime Compatibility Fixtures
+
+These fixtures lock behavior that releases must preserve while the build and
+release system changes. They cover rendered comments, IAM expansion, grouping,
+truncation, no-op results, input failures, and review-comment synchronization.
+
+Update an expected result only when the related behavior or locked IAM dataset
+is intentionally changing. Review the fixture change alongside the production
+change that requires it.

--- a/fixtures/compatibility/grouped-comment.json
+++ b/fixtures/compatibility/grouped-comment.json
@@ -1,0 +1,18 @@
+{
+  "matches": [
+    { "action": "s3:Get*", "line": 10, "file": "policy.json" },
+    { "action": "s3:GetB*", "line": 10, "file": "policy.json" },
+    { "action": "s3:Get*", "line": 11, "file": "policy.json" }
+  ],
+  "expandedActions": [
+    ["s3:Get*", ["s3:GetObject", "s3:GetBucket"]],
+    ["s3:GetB*", ["s3:GetBucket", "s3:GetBucketAcl"]]
+  ],
+  "collapseThreshold": 2,
+  "expectedBlock": {
+    "file": "policy.json",
+    "startLine": 10,
+    "endLine": 11,
+    "actions": ["s3:Get*", "s3:GetB*"]
+  }
+}

--- a/fixtures/compatibility/grouped-comment.txt
+++ b/fixtures/compatibility/grouped-comment.txt
@@ -1,0 +1,15 @@
+**IAM Wildcard Expansion**
+
+2 wildcard patterns expand to 3 action(s):
+**Patterns:**
+- `s3:Get*`
+- `s3:GetB*`
+
+<details>
+<summary>Click to expand</summary>
+
+1. [`s3:GetBucket`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetBucket)
+1. [`s3:GetBucketAcl`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetBucketAcl)
+1. [`s3:GetObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetObject)
+
+</details>

--- a/fixtures/compatibility/invalid-inputs.json
+++ b/fixtures/compatibility/invalid-inputs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "input": "-1",
+    "message": "Invalid collapse-threshold input: \"-1\". Expected a non-negative safe integer."
+  },
+  {
+    "input": "1.5",
+    "message": "Invalid collapse-threshold input: \"1.5\". Expected a non-negative safe integer."
+  },
+  {
+    "input": "not-a-number",
+    "message": "Invalid collapse-threshold input: \"not-a-number\". Expected a non-negative safe integer."
+  },
+  {
+    "input": "9007199254740992",
+    "message": "Invalid collapse-threshold input: \"9007199254740992\". Expected a non-negative safe integer."
+  }
+]

--- a/fixtures/compatibility/minimal-truncated-comment.json
+++ b/fixtures/compatibility/minimal-truncated-comment.json
@@ -1,0 +1,10 @@
+{
+  "originalActions": ["s3:*"],
+  "expandedActions": [
+    "unknown:Action0",
+    "unknown:Action1",
+    "unknown:Action2"
+  ],
+  "maxCommentBodyLength": 10,
+  "truncationUrl": "https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123"
+}

--- a/fixtures/compatibility/minimal-truncated-comment.txt
+++ b/fixtures/compatibility/minimal-truncated-comment.txt
@@ -1,0 +1,3 @@
+**IAM Wildcard Expansion**
+
+Expanded actions were omitted from this comment to stay within GitHub limits. The full expanded list is in the [workflow run logs](https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123).

--- a/fixtures/compatibility/no-op-scenarios.json
+++ b/fixtures/compatibility/no-op-scenarios.json
@@ -1,0 +1,41 @@
+[
+  {
+    "name": "no files match",
+    "files": [
+      { "filename": "README.md", "patch": "@@ -0,0 +1 @@\n+no IAM policy here" }
+    ],
+    "filePatterns": ["**/*.tf"],
+    "expectedStats": {
+      "filesScanned": 0,
+      "wildcardsFound": 0,
+      "blocksCreated": 0,
+      "actionsExpanded": 0
+    }
+  },
+  {
+    "name": "matched files contain no wildcards",
+    "files": [
+      { "filename": "policy.tf", "patch": "@@ -0,0 +1 @@\n+\"s3:GetObject\"" }
+    ],
+    "filePatterns": ["**/*.tf"],
+    "expectedStats": {
+      "filesScanned": 1,
+      "wildcardsFound": 0,
+      "blocksCreated": 0,
+      "actionsExpanded": 0
+    }
+  },
+  {
+    "name": "wildcards do not expand",
+    "files": [
+      { "filename": "policy.tf", "patch": "@@ -0,0 +1 @@\n+\"unknownservice:Get*\"" }
+    ],
+    "filePatterns": ["**/*.tf"],
+    "expectedStats": {
+      "filesScanned": 1,
+      "wildcardsFound": 1,
+      "blocksCreated": 1,
+      "actionsExpanded": 0
+    }
+  }
+]

--- a/fixtures/compatibility/review-sync-scenarios.json
+++ b/fixtures/compatibility/review-sync-scenarios.json
@@ -1,0 +1,83 @@
+[
+  {
+    "name": "leaves an exact match unchanged",
+    "comments": [
+      { "path": "policy.tf", "line": 10, "body": "**IAM Wildcard Expansion**\n\nsame body" }
+    ],
+    "existingComments": [
+      { "id": 1001, "path": "policy.tf", "line": 10, "body": "**IAM Wildcard Expansion**\n\nsame body" }
+    ],
+    "expectedResult": {
+      "createdCount": 0,
+      "updatedCount": 0,
+      "unchangedCount": 1,
+      "deletedCount": 0,
+      "failedDeleteCount": 0,
+      "preservedCount": 0
+    },
+    "expectedUpdatedIds": [],
+    "expectedDeletedIds": [],
+    "expectedCreatedComments": []
+  },
+  {
+    "name": "updates the replied thread and deletes its duplicate",
+    "comments": [
+      { "path": "policy.tf", "line": 10, "body": "**IAM Wildcard Expansion**\n\nnew body" }
+    ],
+    "existingComments": [
+      { "id": 1001, "path": "policy.tf", "line": 10, "body": "**IAM Wildcard Expansion**\n\nold duplicate" },
+      { "id": 1002, "path": "policy.tf", "line": 10, "body": "**IAM Wildcard Expansion**\n\nold thread", "hasReplies": true }
+    ],
+    "expectedResult": {
+      "createdCount": 0,
+      "updatedCount": 1,
+      "unchangedCount": 0,
+      "deletedCount": 1,
+      "failedDeleteCount": 0,
+      "preservedCount": 0
+    },
+    "expectedUpdatedIds": [1002],
+    "expectedDeletedIds": [1001],
+    "expectedCreatedComments": []
+  },
+  {
+    "name": "creates a current comment and preserves a stale replied thread",
+    "comments": [
+      { "path": "policy.tf", "line": 10, "body": "**IAM Wildcard Expansion**\n\nnew body" }
+    ],
+    "existingComments": [
+      { "id": 1001, "path": "policy.tf", "line": 20, "body": "**IAM Wildcard Expansion**\n\nstale thread", "hasReplies": true }
+    ],
+    "expectedResult": {
+      "createdCount": 1,
+      "updatedCount": 0,
+      "unchangedCount": 0,
+      "deletedCount": 0,
+      "failedDeleteCount": 0,
+      "preservedCount": 1
+    },
+    "expectedUpdatedIds": [],
+    "expectedDeletedIds": [],
+    "expectedCreatedComments": [
+      { "path": "policy.tf", "line": 10, "body": "**IAM Wildcard Expansion**\n\nnew body" }
+    ]
+  },
+  {
+    "name": "deletes an unthreaded stale comment",
+    "comments": [],
+    "existingComments": [
+      { "id": 1001, "path": "policy.tf", "line": 20, "body": "**IAM Wildcard Expansion**\n\nstale body" }
+    ],
+    "expectedResult": {
+      "createdCount": 0,
+      "updatedCount": 0,
+      "unchangedCount": 0,
+      "deletedCount": 1,
+      "failedDeleteCount": 0,
+      "preservedCount": 0
+    },
+    "expectedUpdatedIds": [],
+    "expectedDeletedIds": [1001],
+    "expectedCreatedComments": []
+  }
+]

--- a/fixtures/compatibility/s3-get-tagging-comment.txt
+++ b/fixtures/compatibility/s3-get-tagging-comment.txt
@@ -1,0 +1,9 @@
+**IAM Wildcard Expansion**
+
+`s3:Get*Tagging` expands to 5 action(s):
+
+1. [`s3:GetBucketTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetBucketTagging)
+1. [`s3:GetJobTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetJobTagging)
+1. [`s3:GetObjectTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetObjectTagging)
+1. [`s3:GetObjectVersionTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetObjectVersionTagging)
+1. [`s3:GetStorageLensConfigurationTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetStorageLensConfigurationTagging)

--- a/fixtures/compatibility/s3-get-tagging.json
+++ b/fixtures/compatibility/s3-get-tagging.json
@@ -1,0 +1,18 @@
+{
+  "files": [
+    {
+      "filename": "fixtures/compatibility/policy.tf",
+      "patch": "@@ -0,0 +1,5 @@\n+locals {\n+  policy_actions = [\n+    \"s3:Get*Tagging\",\n+  ]\n+}"
+    }
+  ],
+  "filePatterns": ["**/*.tf"],
+  "collapseThreshold": 5,
+  "expectedStats": {
+    "filesScanned": 1,
+    "wildcardsFound": 1,
+    "blocksCreated": 1,
+    "actionsExpanded": 1
+  },
+  "expectedPath": "fixtures/compatibility/policy.tf",
+  "expectedLine": 3
+}

--- a/src/compatibility.test.ts
+++ b/src/compatibility.test.ts
@@ -1,0 +1,213 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  createReviewComments,
+  processFiles,
+  type ProcessingStats,
+} from './action.js';
+import { parseCollapseThreshold } from './inputs.js';
+import { syncReviewComments, type SyncReviewCommentsResult } from './github.js';
+import type {
+  PullRequestFile,
+  PullRequestReviewComment,
+  ReviewComment,
+  WildcardBlock,
+  WildcardMatch,
+} from './types.js';
+import { formatCommentResult, groupIntoConsecutiveBlocks } from './utils.js';
+
+const fixtureRoot = new URL('../fixtures/compatibility/', import.meta.url);
+
+function readTextFixture(name: string): string {
+  return readFileSync(new URL(name, fixtureRoot), 'utf8').trimEnd();
+}
+
+function readJsonFixture<T>(name: string): T {
+  return JSON.parse(readTextFixture(name)) as T;
+}
+
+interface ProcessingFixture {
+  readonly files: PullRequestFile[];
+  readonly filePatterns: string[];
+  readonly collapseThreshold: number;
+  readonly expectedStats: ProcessingStats;
+  readonly expectedPath: string;
+  readonly expectedLine: number;
+}
+
+interface GroupedCommentFixture {
+  readonly matches: WildcardMatch[];
+  readonly expandedActions: [string, string[]][];
+  readonly collapseThreshold: number;
+  readonly expectedBlock: WildcardBlock;
+}
+
+interface TruncatedCommentFixture {
+  readonly originalActions: string[];
+  readonly expandedActions: string[];
+  readonly maxCommentBodyLength: number;
+  readonly truncationUrl: string;
+}
+
+interface NoOpFixture {
+  readonly name: string;
+  readonly files: PullRequestFile[];
+  readonly filePatterns: string[];
+  readonly expectedStats: ProcessingStats;
+}
+
+interface InvalidInputFixture {
+  readonly input: string;
+  readonly message: string;
+}
+
+interface ReviewSyncFixture {
+  readonly name: string;
+  readonly comments: ReviewComment[];
+  readonly existingComments: PullRequestReviewComment[];
+  readonly expectedResult: SyncReviewCommentsResult;
+  readonly expectedUpdatedIds: number[];
+  readonly expectedDeletedIds: number[];
+  readonly expectedCreatedComments: ReviewComment[];
+}
+
+interface CreateReviewParameters {
+  readonly owner: string;
+  readonly repo: string;
+  readonly pull_number: number;
+  readonly commit_id: string;
+  readonly event: 'COMMENT';
+  readonly comments: ReviewComment[];
+}
+
+interface UpdateReviewCommentParameters {
+  readonly owner: string;
+  readonly repo: string;
+  readonly comment_id: number;
+  readonly body: string;
+}
+
+interface DeleteReviewCommentParameters {
+  readonly owner: string;
+  readonly repo: string;
+  readonly comment_id: number;
+}
+
+describe('runtime compatibility fixtures', () => {
+  it('preserves diff discovery, IAM expansion, links, and exact comment rendering', () => {
+    const fixture = readJsonFixture<ProcessingFixture>('s3-get-tagging.json');
+    const expectedBody = readTextFixture('s3-get-tagging-comment.txt');
+
+    const result = processFiles(
+      fixture.files,
+      fixture.filePatterns,
+      fixture.collapseThreshold,
+    );
+
+    expect(result).toEqual({
+      comments: [{
+        path: fixture.expectedPath,
+        line: fixture.expectedLine,
+        body: expectedBody,
+      }],
+      stats: fixture.expectedStats,
+      truncatedComments: [],
+    });
+  });
+
+  it('preserves grouping, deduplication, sorting, collapsing, and exact Markdown', () => {
+    const fixture = readJsonFixture<GroupedCommentFixture>('grouped-comment.json');
+    const expectedBody = readTextFixture('grouped-comment.txt');
+
+    const blocks = groupIntoConsecutiveBlocks(fixture.matches);
+    expect(blocks).toEqual([fixture.expectedBlock]);
+
+    const comments = createReviewComments(
+      blocks,
+      new Map(fixture.expandedActions),
+      fixture.collapseThreshold,
+    );
+
+    expect(comments).toEqual([{
+      path: fixture.expectedBlock.file,
+      line: fixture.expectedBlock.endLine,
+      body: expectedBody,
+    }]);
+  });
+
+  it('preserves the minimal truncation fallback and workflow log link', () => {
+    const fixture = readJsonFixture<TruncatedCommentFixture>('minimal-truncated-comment.json');
+    const expectedBody = readTextFixture('minimal-truncated-comment.txt');
+
+    expect(formatCommentResult(
+      fixture.originalActions,
+      fixture.expandedActions,
+      {
+        maxCommentBodyLength: fixture.maxCommentBodyLength,
+        truncationUrl: fixture.truncationUrl,
+      },
+    )).toEqual({
+      body: expectedBody,
+      renderedActionsCount: 0,
+      truncated: true,
+    });
+  });
+
+  const noOpFixtures = readJsonFixture<NoOpFixture[]>('no-op-scenarios.json');
+
+  it.each(noOpFixtures)('preserves the $name no-op result', (fixture) => {
+    expect(processFiles(fixture.files, fixture.filePatterns, 5)).toEqual({
+      comments: [],
+      stats: fixture.expectedStats,
+      truncatedComments: [],
+    });
+  });
+
+  const invalidInputFixtures = readJsonFixture<InvalidInputFixture[]>('invalid-inputs.json');
+
+  it.each(invalidInputFixtures)('preserves the failure for collapse-threshold $input', (fixture) => {
+    expect(() => parseCollapseThreshold(fixture.input)).toThrow(fixture.message);
+  });
+
+  const reviewSyncFixtures = readJsonFixture<ReviewSyncFixture[]>('review-sync-scenarios.json');
+
+  it.each(reviewSyncFixtures)('preserves review synchronization when it $name', async (fixture) => {
+    const createdComments: ReviewComment[] = [];
+    const updatedIds: number[] = [];
+    const deletedIds: number[] = [];
+    const octokit = {
+      rest: {
+        pulls: {
+          createReview: (parameters: CreateReviewParameters) => {
+            createdComments.push(...parameters.comments);
+            return Promise.resolve({});
+          },
+          updateReviewComment: (parameters: UpdateReviewCommentParameters) => {
+            updatedIds.push(parameters.comment_id);
+            return Promise.resolve({});
+          },
+          deleteReviewComment: (parameters: DeleteReviewCommentParameters) => {
+            deletedIds.push(parameters.comment_id);
+            return Promise.resolve({});
+          },
+        },
+      },
+    };
+
+    const result = await syncReviewComments(octokit, {
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      pullNumber: 42,
+      commitSha: 'deadbeefcafebabe',
+      comments: fixture.comments,
+      existingComments: fixture.existingComments,
+    });
+
+    expect(result).toEqual(fixture.expectedResult);
+    expect(updatedIds).toEqual(fixture.expectedUpdatedIds);
+    expect(deletedIds).toEqual(fixture.expectedDeletedIds);
+    expect(createdComments).toEqual(fixture.expectedCreatedComments);
+  });
+});


### PR DESCRIPTION
Locks current functionality (IAM expansion, comment rendering, truncation input failure, etc) in reusable fixtures.
This _should_ provide me with a stable baseline before changing the build and release paths.