### PR TITLE
run typecheck checks on tests too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Typecheck production, release tooling, and tests with exact optional property types
+
 ## [1.4.0] - 2026-07-21
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ npm run lint:md
 npm run build
 ```
 
+`npm run typecheck` checks production code, release tooling, and tests with the
+same strict TypeScript configuration.
+
 ## Pull Requests
 
 1. Fork the repo and create a branch from `main`

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -75,7 +75,7 @@ function continueResponses({
         result('{"isDraft":true,"isImmutable":false,"tagName":"v1.3.0","url":"https://example.test/release"}'),
       );
 
-  return new Map([
+  const responses = new Map<string, CommandResult[]>([
     ['which git', [result()]],
     ['which gh', [result()]],
     ['which gpg', [result()]],
@@ -98,14 +98,10 @@ function continueResponses({
       'git rev-parse -q --verify refs/tags/v1.3.0',
       localTagExists ? [result(), result()] : [result('', 1), result('', 1)],
     ],
-    ...(localTagExists ? ([[`git rev-parse v1.3.0^{commit}`, [result(`${localTagCommit}\n`)]]] as const) : []),
     [
       'git ls-remote --exit-code origin refs/tags/v1.3.0',
       remoteTagExists ? [result(`${remoteTagCommit}\trefs/tags/v1.3.0\n`)] : [result('', 2)],
     ],
-    ...(remoteTagExists
-      ? ([[`git ls-remote --tags origin refs/tags/v1.3.0^{}`, [result(`${remoteTagCommit}\trefs/tags/v1.3.0^{}\n`)]]] as const)
-      : ([[`git tag -s v1.3.0 ${releaseSha} -m v1.3.0`, [result()]], ['git push origin refs/tags/v1.3.0', [result()]]] as const)),
     [
       'gh release view v1.3.0 --json isDraft,isImmutable,tagName,url',
       [
@@ -120,38 +116,50 @@ function continueResponses({
         ...releaseViewsAfterVerify,
       ],
     ],
-    ...(releaseAlreadyPublished || draftReleaseExists
-      ? []
-      : ([
-          ['gh release create v1.3.0 --draft --verify-tag --generate-notes', [result()]],
-          ['gh release view v1.3.0 --json isDraft,tagName,url', [result('{"isDraft":true,"tagName":"v1.3.0"}')]],
-        ] as const)),
-    ...(releaseAlreadyPublished
-      ? []
-      : ([
-          [
-            'gh run list --workflow verify-draft-release.yml --event workflow_dispatch --limit 50 --json databaseId,displayTitle --branch v1.3.0',
-            [result('[]'), result('[{"databaseId":456,"displayTitle":"Verify v1.3.0"}]')],
-          ],
-          ['gh workflow run verify-draft-release.yml --ref v1.3.0 -f tag=v1.3.0', [result()]],
-          ['gh run watch 456 --exit-status', [result()]],
-        ] as const)),
     ['./verify-release.sh --tag v1.3.0', [result()]],
     [
       'git ls-remote --refs --tags origin refs/tags/v1',
       [result(oldMajorTagCommit === '' ? '' : `${oldMajorTagCommit}\trefs/tags/v1\n`)],
     ],
     ['git tag -s -f v1 v1.3.0^{commit} -m v1', [result()]],
-    ...(oldMajorTagCommit === ''
-      ? ([['git push origin refs/tags/v1', [result()]]] as const)
-      : ([
-          [
-            `git push --force-with-lease=refs/tags/v1:${oldMajorTagCommit} origin refs/tags/v1`,
-            [result()],
-          ],
-        ] as const)),
     [`git ls-remote --tags origin refs/tags/v1^{}`, [result(`${majorTagCommit}\trefs/tags/v1^{}\n`)]],
   ]);
+
+  if (localTagExists) {
+    responses.set(`git rev-parse v1.3.0^{commit}`, [result(`${localTagCommit}\n`)]);
+  }
+
+  if (remoteTagExists) {
+    responses.set(`git ls-remote --tags origin refs/tags/v1.3.0^{}`, [
+      result(`${remoteTagCommit}\trefs/tags/v1.3.0^{}\n`),
+    ]);
+  } else {
+    responses.set(`git tag -s v1.3.0 ${releaseSha} -m v1.3.0`, [result()]);
+    responses.set('git push origin refs/tags/v1.3.0', [result()]);
+  }
+
+  if (!releaseAlreadyPublished && !draftReleaseExists) {
+    responses.set('gh release create v1.3.0 --draft --verify-tag --generate-notes', [result()]);
+    responses.set('gh release view v1.3.0 --json isDraft,tagName,url', [
+      result('{"isDraft":true,"tagName":"v1.3.0"}'),
+    ]);
+  }
+
+  if (!releaseAlreadyPublished) {
+    responses.set(
+      'gh run list --workflow verify-draft-release.yml --event workflow_dispatch --limit 50 --json databaseId,displayTitle --branch v1.3.0',
+      [result('[]'), result('[{"databaseId":456,"displayTitle":"Verify v1.3.0"}]')],
+    );
+    responses.set('gh workflow run verify-draft-release.yml --ref v1.3.0 -f tag=v1.3.0', [result()]);
+    responses.set('gh run watch 456 --exit-status', [result()]);
+  }
+
+  const pushMajorTagCommand = oldMajorTagCommit === ''
+    ? 'git push origin refs/tags/v1'
+    : `git push --force-with-lease=refs/tags/v1:${oldMajorTagCommit} origin refs/tags/v1`;
+  responses.set(pushMajorTagCommand, [result()]);
+
+  return responses;
 }
 
 describe('runReleaseCli', () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -73,11 +73,7 @@ function buildReviewComments(
       a.toLowerCase().localeCompare(b.toLowerCase())
     );
 
-    const formatOptions: FormatOptions = {
-      collapseThreshold,
-      truncationUrl: options.truncationUrl,
-      maxCommentBodyLength: options.maxCommentBodyLength,
-    };
+    const formatOptions: FormatOptions = { collapseThreshold, ...options };
     const formattedComment = formatCommentResult(originalActions, uniqueExpanded, formatOptions);
 
     comments.push({

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -220,8 +220,8 @@ describe('syncReviewComments', () => {
       repo: 'expand-aws-iam-wildcards',
       comment_id: 1001,
     });
-    expect(octokit.rest.pulls.createReview.mock.invocationCallOrder[0]).toBeLessThan(
-      octokit.rest.pulls.deleteReviewComment.mock.invocationCallOrder[0],
+    expect(octokit.rest.pulls.createReview).toHaveBeenCalledBefore(
+      octokit.rest.pulls.deleteReviewComment,
     );
   });
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -95,12 +95,13 @@ describe('runAction integration', () => {
     comment_id: number;
     body: string;
   }) => {
-    const comment = reviewComments.find((entry) => entry.id === parameters.comment_id);
+    const commentIndex = reviewComments.findIndex((entry) => entry.id === parameters.comment_id);
+    const comment = reviewComments[commentIndex];
     if (!comment) {
       throw new Error(`Missing mocked review comment ${parameters.comment_id}`);
     }
 
-    comment.body = parameters.body;
+    reviewComments[commentIndex] = { ...comment, body: parameters.body };
     return {};
   });
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -175,7 +175,7 @@ describe('runAction', () => {
       [{ filename: 'policy.tf', patch: '+ "s3:Get*"' }],
       ['**/*.tf', '**/*.json'],
       5,
-      { truncationUrl: undefined },
+      {},
     );
     expect(githubApiMocks.syncReviewComments).toHaveBeenCalledWith({ tag: 'octokit' }, {
       owner: 'thekbb',
@@ -307,7 +307,7 @@ describe('runAction', () => {
       [],
       ['**/*.tf', '**/*.json'],
       5,
-      { truncationUrl: undefined },
+      {},
     );
     expect(coreMocks.warning).toHaveBeenCalledWith(
       'Truncated 1 review comment(s) to stay within GitHub comment limits.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,9 @@ export async function runAction(): Promise<void> {
     const pullNumber = context.payload.pull_request.number as number;
     const commitSha = context.payload.pull_request.head.sha as string;
     const workflowRunUrl = getWorkflowRunUrl(owner, repo);
+    const reviewCommentOptions = workflowRunUrl === undefined
+      ? {}
+      : { truncationUrl: workflowRunUrl };
 
     core.info(`Analyzing PR #${pullNumber} in ${owner}/${repo}`);
 
@@ -102,7 +105,7 @@ export async function runAction(): Promise<void> {
       files,
       filePatterns,
       collapseThreshold,
-      { truncationUrl: workflowRunUrl },
+      reviewCommentOptions,
     );
 
     if (stats.filesScanned === 0) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "./dist",
     "rootDir": ".",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
@@ -20,5 +21,5 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src/**/*", "scripts/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Includes tests and release tooling in the strict TypeScript check. Enables exact optional property types and cleans up test models without changing action behavior.