### PR TITLE
Build dist in isolation

### DIFF
--- a/.github/workflows/verify-draft-release.yml
+++ b/.github/workflows/verify-draft-release.yml
@@ -145,11 +145,8 @@ jobs:
       - name: Run unit tests
         run: npm test -- --coverage
 
-      - name: Build action bundle
-        run: npm run build
-
-      - name: Verify committed bundle matches the build output
-        run: git diff --exit-code -- dist/index.js
+      - name: Verify deterministic action bundle
+        run: npm run build:check
 
       - name: Generate build provenance attestation
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Typecheck production, release tooling, and tests with exact optional property types
 - Check README input defaults, example inputs, and runtime paths against action metadata
+- Build and verify the action bundle through an isolated, deterministic TypeScript driver
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ npm run lint:md
 
 # Build
 npm run build
+
+# Rebuild twice and compare without changing dist/
+npm run build:check
 ```
 
 `npm run typecheck` checks production code, release tooling, and tests with the
@@ -36,6 +39,11 @@ same strict TypeScript configuration.
 
 `npm run docs:check` keeps README input names, defaults, example inputs, and the
 runtime entry aligned with `action.yml` and `package.json`.
+
+`npm run build` compiles through the repository-local `ncc` executable in a
+temporary directory before replacing `dist/index.js`. `npm run build:check`
+rebuilds twice and compares both results with the committed bundle without
+modifying `dist/`.
 
 ## Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "node": ">=24.19.0"
   },
   "scripts": {
-    "build": "ncc build src/index.ts -o dist --no-source-map-register --license licenses.txt && rm -rf dist/licenses.txt dist/package.json dist/src dist/scripts",
+    "build": "tsx scripts/build.ts",
+    "build:check": "tsx scripts/build.ts --check",
     "check": "npm run lint && npm run lint:md && npm run docs:check && npm run typecheck && npm run test:coverage && npm run build",
     "docs:check": "tsx scripts/check-docs.ts",
     "lint": "eslint .",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import {
+  checkCommittedBundle,
+  type BundleCompiler,
+  writeCommittedBundle,
+} from './release/build.js';
+
+const repositoryRoot = resolve(import.meta.dirname, '..');
+const nccCli = resolve(repositoryRoot, 'node_modules/@vercel/ncc/dist/ncc/cli.js');
+
+const compile: BundleCompiler = (outputDirectory) => {
+  const result = spawnSync(process.execPath, [
+    nccCli,
+    'build',
+    'src/index.ts',
+    '-o',
+    outputDirectory,
+    '--no-source-map-register',
+    '--license',
+    'licenses.txt',
+  ], {
+    cwd: repositoryRoot,
+    stdio: 'inherit',
+  });
+
+  if (result.error !== undefined) throw result.error;
+  if (result.status !== 0) throw new Error(`ncc failed with exit status ${result.status ?? 1}`);
+};
+
+try {
+  const [operation, ...unexpectedArguments] = process.argv.slice(2);
+  if (unexpectedArguments.length > 0 || (operation !== undefined && operation !== '--check')) {
+    throw new Error('usage: tsx scripts/build.ts [--check]');
+  }
+
+  if (operation === '--check') {
+    checkCommittedBundle(repositoryRoot, compile);
+    console.log('Repeated builds match the committed dist/index.js.');
+  } else {
+    writeCommittedBundle(repositoryRoot, compile);
+    console.log('Built dist/index.js.');
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/release/build.test.ts
+++ b/scripts/release/build.test.ts
@@ -93,6 +93,14 @@ describe('build output validation', () => {
     });
   });
 
+  it('creates dist when it does not exist', () => {
+    withFixture((repositoryRoot) => {
+      writeCommittedBundle(repositoryRoot, compiler({ 'index.js': 'new bundle' }));
+
+      expect(readFileSync(join(repositoryRoot, 'dist/index.js'), 'utf8')).toBe('new bundle');
+    });
+  });
+
   it('checks two clean builds and the committed bundle', () => {
     withFixture((repositoryRoot) => {
       writeFiles(join(repositoryRoot, 'dist'), { 'index.js': 'same bundle' });

--- a/scripts/release/build.test.ts
+++ b/scripts/release/build.test.ts
@@ -1,0 +1,222 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertBundleOutput,
+  assertBundlesMatch,
+  type BundleCompiler,
+  checkCommittedBundle,
+  withTemporaryBundle,
+  writeCommittedBundle,
+} from './build.js';
+
+function withFixture<T>(useFixture: (directory: string) => T): T {
+  const directory = mkdtempSync(join(tmpdir(), 'build-test-'));
+  try {
+    return useFixture(directory);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function writeFiles(directory: string, files: Readonly<Record<string, string>>): void {
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const path = join(directory, relativePath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, contents);
+  }
+}
+
+function compiler(files: Readonly<Record<string, string>>): BundleCompiler {
+  return (outputDirectory) => writeFiles(outputDirectory, files);
+}
+
+describe('build output validation', () => {
+  it('accepts the single runtime bundle', () => {
+    withFixture((directory) => {
+      writeFiles(directory, { 'index.js': 'bundle' });
+      expect(() => assertBundleOutput(directory, 'generated')).not.toThrow();
+    });
+  });
+
+  it('reports missing and unexpected artifacts with exact paths', () => {
+    withFixture((directory) => {
+      writeFiles(directory, { 'nested/debug.js': 'debug' });
+      expect(() => assertBundleOutput(directory, 'generated')).toThrow([
+        'Missing generated artifact: dist/index.js',
+        'Unexpected generated artifact: dist/nested/debug.js',
+      ].join('\n'));
+    });
+  });
+
+  it('reports changed bundle contents', () => {
+    withFixture((directory) => {
+      const expected = join(directory, 'expected');
+      const actual = join(directory, 'actual');
+      writeFiles(expected, { 'index.js': 'first' });
+      writeFiles(actual, { 'index.js': 'second' });
+
+      expect(() => assertBundlesMatch(expected, actual, 'Build')).toThrow(
+        'Build differs: dist/index.js',
+      );
+    });
+  });
+
+  it('removes ncc helper output before installing the bundle', () => {
+    withFixture((repositoryRoot) => {
+      writeFiles(join(repositoryRoot, 'dist'), {
+        'index.js': 'old bundle',
+        'old.js': 'old artifact',
+      });
+
+      writeCommittedBundle(repositoryRoot, compiler({
+        'index.js': 'new bundle',
+        'licenses.txt': 'licenses',
+        'package.json': '{}',
+        'scripts/helper.js': 'helper',
+        'src/source.ts': 'source',
+      }));
+
+      expect(readdirSync(join(repositoryRoot, 'dist'))).toEqual(['index.js']);
+      expect(readFileSync(join(repositoryRoot, 'dist/index.js'), 'utf8')).toBe('new bundle');
+    });
+  });
+
+  it('checks two clean builds and the committed bundle', () => {
+    withFixture((repositoryRoot) => {
+      writeFiles(join(repositoryRoot, 'dist'), { 'index.js': 'same bundle' });
+      let compileCount = 0;
+      const compile: BundleCompiler = (outputDirectory) => {
+        compileCount += 1;
+        writeFiles(outputDirectory, { 'index.js': 'same bundle' });
+      };
+
+      expect(() => checkCommittedBundle(repositoryRoot, compile)).not.toThrow();
+      expect(compileCount).toBe(2);
+    });
+  });
+
+  it('rejects nondeterministic repeated builds', () => {
+    withFixture((repositoryRoot) => {
+      writeFiles(join(repositoryRoot, 'dist'), { 'index.js': 'bundle 1' });
+      let compileCount = 0;
+      const compile: BundleCompiler = (outputDirectory) => {
+        compileCount += 1;
+        writeFiles(outputDirectory, { 'index.js': `bundle ${compileCount}` });
+      };
+
+      expect(() => checkCommittedBundle(repositoryRoot, compile)).toThrow(
+        'Repeated build differs: dist/index.js',
+      );
+    });
+  });
+
+  it('rejects stale committed file sets', () => {
+    withFixture((repositoryRoot) => {
+      writeFiles(join(repositoryRoot, 'dist'), {
+        'index.js': 'bundle',
+        'unexpected.js': 'unexpected',
+      });
+
+      expect(() => checkCommittedBundle(repositoryRoot, compiler({ 'index.js': 'bundle' }))).toThrow(
+        'Unexpected committed artifact: dist/unexpected.js',
+      );
+    });
+  });
+
+  it('reports a missing committed bundle with its exact path', () => {
+    withFixture((repositoryRoot) => {
+      expect(() => checkCommittedBundle(repositoryRoot, compiler({ 'index.js': 'bundle' }))).toThrow(
+        'Missing committed artifact: dist/index.js',
+      );
+    });
+  });
+
+  it('preserves the committed bundle when compilation fails', () => {
+    withFixture((repositoryRoot) => {
+      const committedBundle = join(repositoryRoot, 'dist/index.js');
+      writeFiles(join(repositoryRoot, 'dist'), { 'index.js': 'existing bundle' });
+
+      expect(() => writeCommittedBundle(repositoryRoot, () => {
+        throw new Error('compiler failed');
+      })).toThrow('compiler failed');
+      expect(readFileSync(committedBundle, 'utf8')).toBe('existing bundle');
+    });
+  });
+
+  it('does not modify dist when verification fails', () => {
+    withFixture((repositoryRoot) => {
+      const committedDist = join(repositoryRoot, 'dist');
+      writeFiles(committedDist, {
+        'index.js': 'existing bundle',
+        'unexpected.js': 'existing extra file',
+      });
+
+      expect(() => checkCommittedBundle(
+        repositoryRoot,
+        compiler({ 'index.js': 'new bundle' }),
+      )).toThrow('Unexpected committed artifact: dist/unexpected.js');
+      expect(readFileSync(join(committedDist, 'index.js'), 'utf8')).toBe('existing bundle');
+      expect(readFileSync(join(committedDist, 'unexpected.js'), 'utf8')).toBe('existing extra file');
+    });
+  });
+
+  it('cleans temporary output after compiler failure', () => {
+    let outputDirectory = '';
+    expect(() => withTemporaryBundle((output) => {
+      outputDirectory = output;
+      throw new Error('compiler failed');
+    }, () => undefined)).toThrow('compiler failed');
+    expect(existsSync(outputDirectory)).toBe(false);
+  });
+
+  it('refuses to replace a symbolic dist directory', () => {
+    withFixture((repositoryRoot) => {
+      const realDirectory = join(repositoryRoot, 'real-dist');
+      mkdirSync(realDirectory);
+      symlinkSync(realDirectory, join(repositoryRoot, 'dist'));
+
+      expect(() => writeCommittedBundle(repositoryRoot, compiler({ 'index.js': 'bundle' }))).toThrow(
+        'Refusing to replace dist because it is not a regular directory',
+      );
+      expect(existsSync(realDirectory)).toBe(true);
+    });
+  });
+
+  it('refuses to replace a regular file at dist', () => {
+    withFixture((repositoryRoot) => {
+      const distPath = join(repositoryRoot, 'dist');
+      writeFileSync(distPath, 'not a directory');
+
+      expect(() => writeCommittedBundle(repositoryRoot, compiler({ 'index.js': 'bundle' }))).toThrow(
+        'Refusing to replace dist because it is not a regular directory',
+      );
+      expect(readFileSync(distPath, 'utf8')).toBe('not a directory');
+    });
+  });
+
+  it('refuses to replace dist when it contains a symbolic link', () => {
+    withFixture((repositoryRoot) => {
+      const linkedFile = join(repositoryRoot, 'linked-file');
+      writeFileSync(linkedFile, 'outside dist');
+      mkdirSync(join(repositoryRoot, 'dist'));
+      symlinkSync(linkedFile, join(repositoryRoot, 'dist/linked-file'));
+
+      expect(() => writeCommittedBundle(repositoryRoot, compiler({ 'index.js': 'bundle' }))).toThrow(
+        'Unexpected symbolic link in build output: dist/linked-file',
+      );
+      expect(readFileSync(linkedFile, 'utf8')).toBe('outside dist');
+    });
+  });
+});

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -1,0 +1,128 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, posix, resolve } from 'node:path';
+
+const RELEASE_FILE = 'index.js';
+const NCC_AUXILIARY_OUTPUTS = ['licenses.txt', 'package.json', 'src', 'scripts'] as const;
+
+export type BundleCompiler = (outputDirectory: string) => void;
+
+function artifactPath(relativePath: string): string {
+  return `dist/${relativePath}`;
+}
+
+function listFiles(directory: string, relativeDirectory = ''): string[] {
+  const currentDirectory = join(directory, relativeDirectory);
+  if (!existsSync(currentDirectory)) return [];
+
+  const files: string[] = [];
+  for (const entry of readdirSync(currentDirectory, { withFileTypes: true })) {
+    const relativePath = posix.join(relativeDirectory, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Unexpected symbolic link in build output: ${artifactPath(relativePath)}`);
+    }
+    if (entry.isDirectory()) {
+      files.push(...listFiles(directory, relativePath));
+    } else if (entry.isFile()) {
+      files.push(relativePath);
+    } else {
+      throw new Error(`Unexpected entry in build output: ${artifactPath(relativePath)}`);
+    }
+  }
+  return files.sort();
+}
+
+function removeNccAuxiliaryOutputs(outputDirectory: string): void {
+  for (const relativePath of NCC_AUXILIARY_OUTPUTS) {
+    rmSync(join(outputDirectory, relativePath), { force: true, recursive: true });
+  }
+}
+
+export function assertBundleOutput(directory: string, label: string): void {
+  const files = listFiles(directory);
+  const errors: string[] = [];
+
+  if (!files.includes(RELEASE_FILE)) {
+    errors.push(`Missing ${label} artifact: ${artifactPath(RELEASE_FILE)}`);
+  }
+  for (const file of files) {
+    if (file !== RELEASE_FILE) {
+      errors.push(`Unexpected ${label} artifact: ${artifactPath(file)}`);
+    }
+  }
+
+  if (errors.length > 0) throw new Error(errors.join('\n'));
+}
+
+export function assertBundlesMatch(
+  expectedDirectory: string,
+  actualDirectory: string,
+  label: string,
+): void {
+  assertBundleOutput(expectedDirectory, 'generated');
+  assertBundleOutput(actualDirectory, 'committed');
+
+  const expected = readFileSync(join(expectedDirectory, RELEASE_FILE));
+  const actual = readFileSync(join(actualDirectory, RELEASE_FILE));
+  if (!expected.equals(actual)) {
+    throw new Error(`${label} differs: ${artifactPath(RELEASE_FILE)}`);
+  }
+}
+
+export function withTemporaryBundle<T>(
+  compile: BundleCompiler,
+  useBundle: (outputDirectory: string) => T,
+): T {
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'expand-aws-iam-wildcards-build-'));
+  const outputDirectory = join(temporaryRoot, 'dist');
+
+  try {
+    mkdirSync(outputDirectory, { recursive: true });
+    compile(outputDirectory);
+    removeNccAuxiliaryOutputs(outputDirectory);
+    assertBundleOutput(outputDirectory, 'generated');
+    return useBundle(outputDirectory);
+  } finally {
+    rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+}
+
+function assertReplaceableDist(directory: string): void {
+  if (!existsSync(directory)) return;
+  const status = lstatSync(directory);
+  if (status.isSymbolicLink() || !status.isDirectory()) {
+    throw new Error('Refusing to replace dist because it is not a regular directory');
+  }
+  listFiles(directory);
+}
+
+export function writeCommittedBundle(repositoryRoot: string, compile: BundleCompiler): void {
+  const committedDist = resolve(repositoryRoot, 'dist');
+
+  withTemporaryBundle(compile, (generatedDist) => {
+    assertReplaceableDist(committedDist);
+    rmSync(committedDist, { force: true, recursive: true });
+    mkdirSync(committedDist, { recursive: true });
+    copyFileSync(join(generatedDist, RELEASE_FILE), join(committedDist, RELEASE_FILE));
+  });
+}
+
+export function checkCommittedBundle(repositoryRoot: string, compile: BundleCompiler): void {
+  const committedDist = resolve(repositoryRoot, 'dist');
+
+  withTemporaryBundle(compile, (firstBuild) => {
+    withTemporaryBundle(compile, (secondBuild) => {
+      assertBundlesMatch(firstBuild, secondBuild, 'Repeated build');
+      assertBundlesMatch(firstBuild, committedDist, 'Committed bundle');
+    });
+  });
+}


### PR DESCRIPTION
Replaces the inline `ncc` command with a tested TypeScript build driver. Rejects missing, unexpected, stale, and janky runtime output without rewriting `dist/` during verification.