### PR TITLE
Smoke test the compiled action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
         with:
           files: ./coverage/lcov.info
 
-      - name: Build
-        run: npm run build
+      - name: Smoke test compiled action
+        run: npm run build:smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typecheck production, release tooling, and tests with exact optional property types
 - Check README input defaults, example inputs, and runtime paths against action metadata
 - Build and verify the action bundle through an isolated, deterministic TypeScript driver
+- Smoke-test the compiled action without changing the committed runtime bundle
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ npm run build
 
 # Rebuild twice and compare without changing dist/
 npm run build:check
+
+# Build temporarily and run the compiled action with a safe non-PR event
+npm run build:smoke
 ```
 
 `npm run typecheck` checks production code, release tooling, and tests with the
@@ -43,7 +46,9 @@ runtime entry aligned with `action.yml` and `package.json`.
 `npm run build` compiles through the repository-local `ncc` executable in a
 temporary directory before replacing `dist/index.js`. `npm run build:check`
 rebuilds twice and compares both results with the committed bundle without
-modifying `dist/`.
+modifying `dist/`. `npm run build:smoke` builds temporarily, executes the entry
+declared by `action.yml` with a synthetic non-PR event, and cleans up without
+changing `dist/`.
 
 ## Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsx scripts/build.ts",
     "build:check": "tsx scripts/build.ts --check",
-    "check": "npm run lint && npm run lint:md && npm run docs:check && npm run typecheck && npm run test:coverage && npm run build",
+    "build:smoke": "tsx scripts/build.ts --smoke",
+    "check": "npm run lint && npm run lint:md && npm run docs:check && npm run typecheck && npm run test:coverage && npm run build:smoke",
     "docs:check": "tsx scripts/check-docs.ts",
     "lint": "eslint .",
     "lint:md": "markdownlint '**/*.md' --ignore node_modules",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,11 +1,14 @@
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import {
   checkCommittedBundle,
   type BundleCompiler,
+  withTemporaryBundle,
   writeCommittedBundle,
 } from './release/build.js';
+import { smokeTestAction } from './release/smoke.js';
 
 const repositoryRoot = resolve(import.meta.dirname, '..');
 const nccCli = resolve(repositoryRoot, 'node_modules/@vercel/ncc/dist/ncc/cli.js');
@@ -31,13 +34,20 @@ const compile: BundleCompiler = (outputDirectory) => {
 
 try {
   const [operation, ...unexpectedArguments] = process.argv.slice(2);
-  if (unexpectedArguments.length > 0 || (operation !== undefined && operation !== '--check')) {
-    throw new Error('usage: tsx scripts/build.ts [--check]');
+  if (
+    unexpectedArguments.length > 0 ||
+    (operation !== undefined && operation !== '--check' && operation !== '--smoke')
+  ) {
+    throw new Error('usage: tsx scripts/build.ts [--check|--smoke]');
   }
 
   if (operation === '--check') {
     checkCommittedBundle(repositoryRoot, compile);
     console.log('Repeated builds match the committed dist/index.js.');
+  } else if (operation === '--smoke') {
+    const actionYaml = readFileSync(resolve(repositoryRoot, 'action.yml'), 'utf8');
+    withTemporaryBundle(compile, (outputDirectory) => smokeTestAction(actionYaml, outputDirectory));
+    console.log('Temporary dist/index.js passed the non-PR smoke test.');
   } else {
     writeCommittedBundle(repositoryRoot, compile);
     console.log('Built dist/index.js.');

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join, posix, resolve } from 'node:path';
 
-const RELEASE_FILE = 'index.js';
+export const RELEASE_FILE = 'index.js';
 const NCC_AUXILIARY_OUTPUTS = ['licenses.txt', 'package.json', 'src', 'scripts'] as const;
 
 export type BundleCompiler = (outputDirectory: string) => void;

--- a/scripts/release/smoke.test.ts
+++ b/scripts/release/smoke.test.ts
@@ -1,0 +1,94 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertSmokeResult,
+  EXPECTED_SKIP_MESSAGE,
+  resolveActionRuntime,
+  smokeTestAction,
+} from './smoke.js';
+import { withTemporaryBundle } from './build.js';
+
+const actionYaml = `
+runs:
+  using: node24
+  main: dist/index.js
+`;
+
+function withRuntime(
+  source: string,
+  useRuntime: (outputDirectory: string) => void,
+): void {
+  withTemporaryBundle((outputDirectory) => {
+    writeFileSync(join(outputDirectory, 'index.js'), source);
+  }, useRuntime);
+}
+
+describe('compiled action smoke test', () => {
+  it('runs the declared action entry with a safe non-PR event', () => {
+    withRuntime(`
+      const fs = require('node:fs');
+      const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+      if (process.env.GITHUB_EVENT_NAME !== 'push') process.exit(2);
+      if (Object.keys(event).length !== 0) process.exit(3);
+      process.stdout.write('${EXPECTED_SKIP_MESSAGE}');
+    `, (outputDirectory) => {
+      expect(() => smokeTestAction(actionYaml, outputDirectory)).not.toThrow();
+    });
+  });
+
+  it('fails when the declared runtime is stale', () => {
+    withRuntime(`process.stdout.write('${EXPECTED_SKIP_MESSAGE}');`, (outputDirectory) => {
+      const staleAction = actionYaml.replace('dist/index.js', 'dist/missing.js');
+      expect(() => smokeTestAction(staleAction, outputDirectory)).toThrow(
+        'Compiled action smoke test failed with exit status 1',
+      );
+    });
+  });
+
+  it('fails when the bundle omits a runtime dependency', () => {
+    withRuntime("require('definitely-not-a-real-runtime-dependency');", (outputDirectory) => {
+      expect(() => smokeTestAction(actionYaml, outputDirectory)).toThrow(
+        'Compiled action smoke test failed with exit status 1',
+      );
+    });
+  });
+
+  it('rejects runtime paths outside dist', () => {
+    expect(() => resolveActionRuntime(
+      actionYaml.replace('dist/index.js', '../index.js'),
+      '/temporary/dist',
+    )).toThrow('action.yml runtime must be a file under dist/: ../index.js');
+    expect(() => resolveActionRuntime(
+      actionYaml.replace('dist/index.js', 'dist'),
+      '/temporary/dist',
+    )).toThrow('action.yml runtime must be a file under dist/: dist');
+  });
+
+  it('rejects malformed action metadata', () => {
+    expect(() => resolveActionRuntime('name: invalid', '/temporary/dist')).toThrow(
+      'action.yml runs.main must be a string',
+    );
+  });
+
+  it('reports subprocess and output failures', () => {
+    const spawnError = new Error('spawn failed');
+    expect(() => assertSmokeResult({
+      error: spawnError,
+      status: null,
+      stderr: '',
+      stdout: '',
+    })).toThrow(spawnError);
+    expect(() => assertSmokeResult({
+      status: null,
+      stderr: 'timed out',
+      stdout: '',
+    })).toThrow('Compiled action smoke test failed with exit status 1: timed out');
+    expect(() => assertSmokeResult({
+      status: 0,
+      stderr: '',
+      stdout: 'wrong output',
+    })).toThrow('Compiled action did not log the expected skip message. Output: wrong output');
+  });
+});

--- a/scripts/release/smoke.test.ts
+++ b/scripts/release/smoke.test.ts
@@ -27,15 +27,27 @@ function withRuntime(
 
 describe('compiled action smoke test', () => {
   it('runs the declared action entry with a safe non-PR event', () => {
-    withRuntime(`
-      const fs = require('node:fs');
-      const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
-      if (process.env.GITHUB_EVENT_NAME !== 'push') process.exit(2);
-      if (Object.keys(event).length !== 0) process.exit(3);
-      process.stdout.write('${EXPECTED_SKIP_MESSAGE}');
-    `, (outputDirectory) => {
-      expect(() => smokeTestAction(actionYaml, outputDirectory)).not.toThrow();
-    });
+    const previousValue = process.env.EXPAND_IAM_SMOKE_PARENT_SECRET;
+    process.env.EXPAND_IAM_SMOKE_PARENT_SECRET = 'must-not-reach-child';
+
+    try {
+      withRuntime(`
+        const fs = require('node:fs');
+        const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+        if (process.env.GITHUB_EVENT_NAME !== 'push') process.exit(2);
+        if (Object.keys(event).length !== 0) process.exit(3);
+        if (process.env.EXPAND_IAM_SMOKE_PARENT_SECRET !== undefined) process.exit(4);
+        process.stdout.write('${EXPECTED_SKIP_MESSAGE}');
+      `, (outputDirectory) => {
+        expect(() => smokeTestAction(actionYaml, outputDirectory)).not.toThrow();
+      });
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env.EXPAND_IAM_SMOKE_PARENT_SECRET;
+      } else {
+        process.env.EXPAND_IAM_SMOKE_PARENT_SECRET = previousValue;
+      }
+    }
   });
 
   it('fails when the declared runtime is stale', () => {

--- a/scripts/release/smoke.ts
+++ b/scripts/release/smoke.ts
@@ -24,7 +24,7 @@ export function resolveActionRuntime(actionYaml: string, outputDirectory: string
   }
 
   const relativeRuntime = posix.relative('dist', metadata.runs.main);
-  if (relativeRuntime === '' || relativeRuntime.startsWith('../') || posix.isAbsolute(relativeRuntime)) {
+  if (relativeRuntime === '' || relativeRuntime.startsWith('../')) {
     throw new Error(`action.yml runtime must be a file under dist/: ${metadata.runs.main}`);
   }
   return resolve(outputDirectory, relativeRuntime);

--- a/scripts/release/smoke.ts
+++ b/scripts/release/smoke.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, posix, resolve } from 'node:path';
+import { load } from 'js-yaml';
+
+export const EXPECTED_SKIP_MESSAGE = 'This action only runs on pull requests. Skipping.';
+
+interface SmokeResult {
+  readonly error?: Error;
+  readonly status: number | null;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function resolveActionRuntime(actionYaml: string, outputDirectory: string): string {
+  const metadata: unknown = load(actionYaml);
+  if (!isRecord(metadata) || !isRecord(metadata.runs) || typeof metadata.runs.main !== 'string') {
+    throw new Error('action.yml runs.main must be a string');
+  }
+
+  const relativeRuntime = posix.relative('dist', metadata.runs.main);
+  if (relativeRuntime === '' || relativeRuntime.startsWith('../') || posix.isAbsolute(relativeRuntime)) {
+    throw new Error(`action.yml runtime must be a file under dist/: ${metadata.runs.main}`);
+  }
+  return resolve(outputDirectory, relativeRuntime);
+}
+
+export function assertSmokeResult(result: SmokeResult): void {
+  if (result.error !== undefined) throw result.error;
+
+  const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
+  if (result.status !== 0) {
+    throw new Error(`Compiled action smoke test failed with exit status ${result.status ?? 1}: ${output}`);
+  }
+  if (!result.stdout.includes(EXPECTED_SKIP_MESSAGE)) {
+    throw new Error(`Compiled action did not log the expected skip message. Output: ${output}`);
+  }
+}
+
+export function smokeTestAction(actionYaml: string, outputDirectory: string): void {
+  const eventDirectory = mkdtempSync(join(tmpdir(), 'expand-aws-iam-wildcards-smoke-'));
+  const eventPath = join(eventDirectory, 'event.json');
+
+  try {
+    writeFileSync(eventPath, '{}\n');
+    const result = spawnSync(process.execPath, [resolveActionRuntime(actionYaml, outputDirectory)], {
+      encoding: 'utf8',
+      env: {
+        GITHUB_ACTIONS: 'true',
+        GITHUB_EVENT_NAME: 'push',
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_REPOSITORY: 'thekbb/expand-aws-iam-wildcards',
+      },
+      timeout: 15_000,
+    });
+    assertSmokeResult({
+      status: result.status,
+      stderr: result.stderr ?? '',
+      stdout: result.stdout ?? '',
+      ...(result.error === undefined ? {} : { error: result.error }),
+    });
+  } finally {
+    rmSync(eventDirectory, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
Builds and executes the runtime declared by action.yml with a safe non-PR event.
This should catch stale entry paths, omitted dependencies, and bundles that cannot start under Node24 without changing `dist/` during normal local or CI checks.