### PR TITLE
rework IAM generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check README input defaults, example inputs, and runtime paths against action metadata
 - Build and verify the action bundle through an isolated, deterministic TypeScript driver
 - Smoke-test the compiled action without changing the committed runtime bundle
+- Generate IAM catalog modules deterministically into an explicit validated directory
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,16 @@ npm run update-iam-data
 npm run build
 ```
 
+The generator writes to `src/` by default. To inspect generated modules without
+changing the tracked files, provide a repository-local or temporary output
+directory:
+
+```bash
+npm run generate-iam-data -- --output-dir /tmp/expand-aws-iam-data
+```
+
+Generation from one locked IAM-data package is byte-for-byte deterministic.
+
 ## Preparing a Release
 
 Release bundles are generated on Ubuntu through GitHub Actions rather than being committed from a local machine.

--- a/scripts/generate-iam-data.ts
+++ b/scripts/generate-iam-data.ts
@@ -2,97 +2,29 @@
  * Generates static IAM action and service-doc metadata at build time.
  * Run with: npm run generate-iam-data
  */
-import { readFileSync, readdirSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { resolve } from 'node:path';
 
-interface IamDataAction {
-  readonly name: string;
+import { generateIamData } from './iam-data/generator.js';
+
+const repositoryRoot = resolve(import.meta.dirname, '..');
+const args = process.argv.slice(2);
+
+try {
+  if (args.length !== 0 && (args.length !== 2 || args[0] !== '--output-dir')) {
+    throw new Error('usage: tsx scripts/generate-iam-data.ts [--output-dir <directory>]');
+  }
+
+  const outputDirectory = args[1] === undefined
+    ? resolve(repositoryRoot, 'src')
+    : resolve(repositoryRoot, args[1]);
+  const result = generateIamData({
+    dataDirectory: resolve(repositoryRoot, 'node_modules/@cloud-copilot/iam-data/data'),
+    outputDirectory,
+    repositoryRoot,
+  });
+
+  console.log(`Generated ${result.actionCount} IAM actions and ${result.serviceCount} service doc slugs`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
 }
-
-const dataDir = join(process.cwd(), 'node_modules/@cloud-copilot/iam-data/data');
-const actionsDir = join(dataDir, 'actions');
-const serviceNamesPath = join(dataDir, 'serviceNames.json');
-
-// Most AWS Service Authorization page slugs are just normalized service names.
-// These overrides cover the legacy docs paths that still do not follow that rule.
-const DOC_SLUG_OVERRIDES: Readonly<Record<string, string>> = {
-  'glacier': 's3glacier',
-  'elasticloadbalancing': 'elasticloadbalancing',
-  'apigateway': 'amazonapigateway',
-  'sso': 'awsiamidentitycentersuccessortoawssinglesignon',
-  'cloudformation': 'awscloudformation',
-  'kinesis': 'amazonkinesis',
-  'es': 'amazonelasticsearchservice',
-  'opensearch': 'amazonopensearchservice',
-  'application-autoscaling': 'applicationautoscaling',
-  'pricing': 'awspricelistservice',
-};
-
-function normalizeServiceName(serviceName: string): string {
-  return serviceName
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '');
-}
-
-function readServicePrefixes(): string[] {
-  return readdirSync(actionsDir)
-    .filter((file) => file.endsWith('.json'))
-    .map((file) => file.replace('.json', ''))
-    .sort();
-}
-
-function readAllActions(servicePrefixes: readonly string[]): string[] {
-  return servicePrefixes
-    .flatMap((servicePrefix) => {
-      const filePath = join(actionsDir, `${servicePrefix}.json`);
-      const data = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, IamDataAction>;
-
-      return Object.values(data)
-        .map((action) => `${servicePrefix}:${action.name}`);
-    })
-    .sort();
-}
-
-function generateServiceDocSlugs(
-  servicePrefixes: readonly string[],
-  serviceNames: Readonly<Record<string, string>>,
-): Record<string, string> {
-  return Object.fromEntries(
-    servicePrefixes.map((servicePrefix) => {
-      const serviceName = serviceNames[servicePrefix];
-      if (!serviceName) {
-        throw new Error(`Missing service name metadata for IAM service prefix: ${servicePrefix}`);
-      }
-
-      return [
-        servicePrefix,
-        DOC_SLUG_OVERRIDES[servicePrefix] ?? normalizeServiceName(serviceName),
-      ];
-    }),
-  );
-}
-
-const servicePrefixes = readServicePrefixes();
-const allActions = readAllActions(servicePrefixes);
-const serviceNames = JSON.parse(
-  readFileSync(serviceNamesPath, 'utf-8'),
-) as Record<string, string>;
-const serviceDocSlugs = generateServiceDocSlugs(servicePrefixes, serviceNames);
-
-const actionsOutput = `// Auto-generated - do not edit
-// Run: npm run generate-iam-data
-
-export const IAM_ACTIONS: readonly string[] = ${JSON.stringify(allActions, null, 2)};
-`;
-
-const serviceDocSlugsOutput = `// Auto-generated - do not edit
-// Run: npm run generate-iam-data
-
-export const SERVICE_DOC_SLUGS: Readonly<Record<string, string>> = ${JSON.stringify(serviceDocSlugs, null, 2)};
-`;
-
-writeFileSync(join(process.cwd(), 'src/iam-actions.ts'), actionsOutput);
-writeFileSync(join(process.cwd(), 'src/service-doc-slugs.ts'), serviceDocSlugsOutput);
-
-console.log(`Generated ${allActions.length} IAM actions and ${servicePrefixes.length} service doc slugs`);

--- a/scripts/iam-data/generator.test.ts
+++ b/scripts/iam-data/generator.test.ts
@@ -123,6 +123,20 @@ describe('generateIamData', () => {
       expect(() => readFileSync(join(outputDirectory, 'service-doc-slugs.ts'), 'utf8')).toThrow();
     });
   });
+
+  it('refuses a directory at a generated output file path', () => {
+    withFixture((repositoryRoot) => {
+      const dataDirectory = createDataFixture(repositoryRoot);
+      const outputDirectory = join(repositoryRoot, 'generated');
+      const actionsOutputPath = join(outputDirectory, 'iam-actions.ts');
+      mkdirSync(actionsOutputPath, { recursive: true });
+
+      expect(() => generateIamData({ dataDirectory, outputDirectory, repositoryRoot })).toThrow(
+        `IAM data output file must be a regular file: ${actionsOutputPath}`,
+      );
+      expect(() => readFileSync(join(outputDirectory, 'service-doc-slugs.ts'), 'utf8')).toThrow();
+    });
+  });
 });
 
 describe('validateGeneratorOutputDirectory', () => {

--- a/scripts/iam-data/generator.test.ts
+++ b/scripts/iam-data/generator.test.ts
@@ -1,0 +1,171 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { generateIamData, validateGeneratorOutputDirectory } from './generator.js';
+
+function withFixture<T>(useFixture: (directory: string) => T): T {
+  const directory = mkdtempSync(join(tmpdir(), 'iam-generator-test-'));
+  try {
+    return useFixture(directory);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function createDataFixture(directory: string): string {
+  const dataDirectory = join(directory, 'data');
+  const actionsDirectory = join(dataDirectory, 'actions');
+  mkdirSync(actionsDirectory, { recursive: true });
+  writeFileSync(join(actionsDirectory, 'zeta.json'), JSON.stringify({
+    second: { name: 'Beta' },
+    first: { name: 'Alpha' },
+  }));
+  writeFileSync(join(actionsDirectory, 'sso.json'), JSON.stringify({
+    create: { name: 'CreateApplication' },
+  }));
+  writeFileSync(join(actionsDirectory, 'README.txt'), 'ignored');
+  writeFileSync(join(dataDirectory, 'serviceNames.json'), JSON.stringify({
+    sso: 'AWS IAM Identity Center',
+    zeta: 'AWS Zeta-Service!',
+  }));
+  return dataDirectory;
+}
+
+function generatedFiles(directory: string): [string, string] {
+  return [
+    readFileSync(join(directory, 'iam-actions.ts'), 'utf8'),
+    readFileSync(join(directory, 'service-doc-slugs.ts'), 'utf8'),
+  ];
+}
+
+describe('generateIamData', () => {
+  it('writes sorted actions and stable documentation slugs to the requested directory', () => {
+    withFixture((repositoryRoot) => {
+      const dataDirectory = createDataFixture(repositoryRoot);
+      const outputDirectory = join(repositoryRoot, 'generated');
+
+      expect(generateIamData({ dataDirectory, outputDirectory, repositoryRoot })).toEqual({
+        actionCount: 3,
+        serviceCount: 2,
+      });
+      const [actions, slugs] = generatedFiles(outputDirectory);
+      expect(actions).toContain('[\n  "sso:CreateApplication",\n  "zeta:Alpha",\n  "zeta:Beta"\n]');
+      expect(slugs).toContain('"sso": "awsiamidentitycentersuccessortoawssinglesignon"');
+      expect(slugs).toContain('"zeta": "awszetaservice"');
+    });
+  });
+
+  it('generates fixture output byte-for-byte identically twice', () => {
+    withFixture((repositoryRoot) => {
+      const dataDirectory = createDataFixture(repositoryRoot);
+      const firstOutput = join(repositoryRoot, 'first');
+      const secondOutput = join(repositoryRoot, 'second');
+
+      generateIamData({ dataDirectory, outputDirectory: firstOutput, repositoryRoot });
+      generateIamData({ dataDirectory, outputDirectory: secondOutput, repositoryRoot });
+
+      expect(generatedFiles(firstOutput)).toEqual(generatedFiles(secondOutput));
+    });
+  });
+
+  it('generates the locked IAM package byte-for-byte identically twice', () => {
+    withFixture((temporaryDirectory) => {
+      const repositoryRoot = resolve(import.meta.dirname, '../..');
+      const dataDirectory = join(repositoryRoot, 'node_modules/@cloud-copilot/iam-data/data');
+      const firstOutput = join(temporaryDirectory, 'first');
+      const secondOutput = join(temporaryDirectory, 'second');
+
+      const firstResult = generateIamData({ dataDirectory, outputDirectory: firstOutput, repositoryRoot });
+      const secondResult = generateIamData({ dataDirectory, outputDirectory: secondOutput, repositoryRoot });
+
+      expect(firstResult.actionCount).toBeGreaterThan(0);
+      expect(firstResult.serviceCount).toBeGreaterThan(0);
+      expect(secondResult).toEqual(firstResult);
+      expect(generatedFiles(secondOutput)).toEqual(generatedFiles(firstOutput));
+    });
+  });
+
+  it('fails when a service name is missing', () => {
+    withFixture((repositoryRoot) => {
+      const dataDirectory = createDataFixture(repositoryRoot);
+      writeFileSync(join(dataDirectory, 'serviceNames.json'), JSON.stringify({ sso: 'Identity Center' }));
+
+      expect(() => generateIamData({
+        dataDirectory,
+        outputDirectory: join(repositoryRoot, 'generated'),
+        repositoryRoot,
+      })).toThrow('Missing service name metadata for IAM service prefix: zeta');
+    });
+  });
+
+  it('refuses generated output files that are symbolic links', () => {
+    withFixture((repositoryRoot) => {
+      const dataDirectory = createDataFixture(repositoryRoot);
+      const outputDirectory = join(repositoryRoot, 'generated');
+      const linkedFile = join(repositoryRoot, 'linked-file');
+      mkdirSync(outputDirectory);
+      writeFileSync(linkedFile, 'do not replace');
+      symlinkSync(linkedFile, join(outputDirectory, 'iam-actions.ts'));
+
+      expect(() => generateIamData({ dataDirectory, outputDirectory, repositoryRoot })).toThrow(
+        `IAM data output file must be a regular file: ${join(outputDirectory, 'iam-actions.ts')}`,
+      );
+      expect(readFileSync(linkedFile, 'utf8')).toBe('do not replace');
+      expect(() => readFileSync(join(outputDirectory, 'service-doc-slugs.ts'), 'utf8')).toThrow();
+    });
+  });
+});
+
+describe('validateGeneratorOutputDirectory', () => {
+  it('allows repository and temporary descendants', () => {
+    withFixture((temporaryDirectory) => {
+      const repositoryRoot = resolve(import.meta.dirname, '../..');
+      expect(validateGeneratorOutputDirectory(
+        repositoryRoot,
+        join(repositoryRoot, '.generated/iam-data'),
+      )).toBe(join(repositoryRoot, '.generated/iam-data'));
+      expect(validateGeneratorOutputDirectory(
+        repositoryRoot,
+        join(temporaryDirectory, 'iam-data'),
+      )).toBe(join(temporaryDirectory, 'iam-data'));
+    });
+  });
+
+  it('rejects broad or unrelated output paths', () => {
+    const repositoryRoot = resolve(import.meta.dirname, '../..');
+    expect(() => validateGeneratorOutputDirectory(repositoryRoot, repositoryRoot)).toThrow(
+      'IAM data output must be inside the repository or temporary directory',
+    );
+    expect(() => validateGeneratorOutputDirectory(repositoryRoot, resolve(repositoryRoot, '..'))).toThrow(
+      'IAM data output must be inside the repository or temporary directory',
+    );
+  });
+
+  it('rejects files and symbolic links as output directories', () => {
+    withFixture((temporaryDirectory) => {
+      const repositoryRoot = resolve(import.meta.dirname, '../..');
+      const filePath = join(temporaryDirectory, 'file');
+      const realDirectory = join(temporaryDirectory, 'real-directory');
+      const linkPath = join(temporaryDirectory, 'linked-directory');
+      writeFileSync(filePath, 'file');
+      mkdirSync(realDirectory);
+      symlinkSync(realDirectory, linkPath);
+
+      expect(() => validateGeneratorOutputDirectory(repositoryRoot, filePath)).toThrow(
+        `IAM data output must be a regular directory: ${filePath}`,
+      );
+      expect(() => validateGeneratorOutputDirectory(repositoryRoot, linkPath)).toThrow(
+        `IAM data output must be a regular directory: ${linkPath}`,
+      );
+    });
+  });
+});

--- a/scripts/iam-data/generator.ts
+++ b/scripts/iam-data/generator.ts
@@ -1,0 +1,153 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+interface IamDataAction {
+  readonly name: string;
+}
+
+export interface GenerateIamDataOptions {
+  readonly dataDirectory: string;
+  readonly outputDirectory: string;
+  readonly repositoryRoot: string;
+}
+
+export interface IamDataGenerationResult {
+  readonly actionCount: number;
+  readonly serviceCount: number;
+}
+
+const DOC_SLUG_OVERRIDES: Readonly<Record<string, string>> = {
+  glacier: 's3glacier',
+  elasticloadbalancing: 'elasticloadbalancing',
+  apigateway: 'amazonapigateway',
+  sso: 'awsiamidentitycentersuccessortoawssinglesignon',
+  cloudformation: 'awscloudformation',
+  kinesis: 'amazonkinesis',
+  es: 'amazonelasticsearchservice',
+  opensearch: 'amazonopensearchservice',
+  'application-autoscaling': 'applicationautoscaling',
+  pricing: 'awspricelistservice',
+};
+
+function normalizeServiceName(serviceName: string): string {
+  return serviceName.trim().toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function isDescendant(parent: string, child: string): boolean {
+  const path = relative(parent, child);
+  return path !== '' && path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path);
+}
+
+export function validateGeneratorOutputDirectory(
+  repositoryRoot: string,
+  outputDirectory: string,
+): string {
+  const resolvedRepository = resolve(repositoryRoot);
+  const resolvedOutput = resolve(outputDirectory);
+  const resolvedTemporaryDirectory = resolve(tmpdir());
+
+  if (
+    !isDescendant(resolvedRepository, resolvedOutput) &&
+    !isDescendant(resolvedTemporaryDirectory, resolvedOutput)
+  ) {
+    throw new Error('IAM data output must be inside the repository or temporary directory');
+  }
+
+  if (existsSync(resolvedOutput)) {
+    const status = lstatSync(resolvedOutput);
+    if (status.isSymbolicLink() || !status.isDirectory()) {
+      throw new Error(`IAM data output must be a regular directory: ${resolvedOutput}`);
+    }
+  }
+
+  return resolvedOutput;
+}
+
+function readServicePrefixes(actionsDirectory: string): string[] {
+  return readdirSync(actionsDirectory)
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => file.slice(0, -'.json'.length))
+    .sort();
+}
+
+function readAllActions(actionsDirectory: string, servicePrefixes: readonly string[]): string[] {
+  return servicePrefixes
+    .flatMap((servicePrefix) => {
+      const filePath = join(actionsDirectory, `${servicePrefix}.json`);
+      const data = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, IamDataAction>;
+      return Object.values(data).map((action) => `${servicePrefix}:${action.name}`);
+    })
+    .sort();
+}
+
+function generateServiceDocSlugs(
+  servicePrefixes: readonly string[],
+  serviceNames: Readonly<Record<string, string>>,
+): Record<string, string> {
+  return Object.fromEntries(servicePrefixes.map((servicePrefix) => {
+    const serviceName = serviceNames[servicePrefix];
+    if (!serviceName) {
+      throw new Error(`Missing service name metadata for IAM service prefix: ${servicePrefix}`);
+    }
+    return [
+      servicePrefix,
+      DOC_SLUG_OVERRIDES[servicePrefix] ?? normalizeServiceName(serviceName),
+    ];
+  }));
+}
+
+function validateOutputFiles(paths: readonly string[]): void {
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    const status = lstatSync(path);
+    if (status.isSymbolicLink() || !status.isFile()) {
+      throw new Error(`IAM data output file must be a regular file: ${path}`);
+    }
+  }
+}
+
+export function generateIamData(options: GenerateIamDataOptions): IamDataGenerationResult {
+  const dataDirectory = resolve(options.dataDirectory);
+  const actionsDirectory = join(dataDirectory, 'actions');
+  const serviceNamesPath = join(dataDirectory, 'serviceNames.json');
+  const outputDirectory = validateGeneratorOutputDirectory(
+    options.repositoryRoot,
+    options.outputDirectory,
+  );
+
+  const servicePrefixes = readServicePrefixes(actionsDirectory);
+  const allActions = readAllActions(actionsDirectory, servicePrefixes);
+  const serviceNames = JSON.parse(readFileSync(serviceNamesPath, 'utf8')) as Record<string, string>;
+  const serviceDocSlugs = generateServiceDocSlugs(servicePrefixes, serviceNames);
+  const actionsOutputPath = join(outputDirectory, 'iam-actions.ts');
+  const serviceDocSlugsOutputPath = join(outputDirectory, 'service-doc-slugs.ts');
+
+  const actionsOutput = `// Auto-generated - do not edit
+// Run: npm run generate-iam-data
+
+export const IAM_ACTIONS: readonly string[] = ${JSON.stringify(allActions, null, 2)};
+`;
+  const serviceDocSlugsOutput = `// Auto-generated - do not edit
+// Run: npm run generate-iam-data
+
+export const SERVICE_DOC_SLUGS: Readonly<Record<string, string>> = ${JSON.stringify(serviceDocSlugs, null, 2)};
+`;
+
+  mkdirSync(outputDirectory, { recursive: true });
+  validateOutputFiles([actionsOutputPath, serviceDocSlugsOutputPath]);
+  writeFileSync(actionsOutputPath, actionsOutput, 'utf8');
+  writeFileSync(serviceDocSlugsOutputPath, serviceDocSlugsOutput, 'utf8');
+
+  return {
+    actionCount: allActions.length,
+    serviceCount: servicePrefixes.length,
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,12 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
       provider: 'v8',
-      include: ['src/**/*.ts', 'scripts/docs-contract.ts', 'scripts/release/**/*.ts'],
+      include: [
+        'src/**/*.ts',
+        'scripts/docs-contract.ts',
+        'scripts/iam-data/**/*.ts',
+        'scripts/release/**/*.ts',
+      ],
       exclude: [
         'src/**/*.test.ts',
         'scripts/release/**/*.test.ts',


### PR DESCRIPTION
Adds a validated output directory to IAM generation and proves repeated output is byte-for-byte identical.

Keeps the tracked src output and current update workflow unchanged.

TL;DR: new IAM generation, no change yet.