### PR TITLE
Validate IAM catalog invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build and verify the action bundle through an isolated, deterministic TypeScript driver
 - Smoke-test the compiled action without changing the committed runtime bundle
 - Generate IAM catalog modules deterministically into an explicit validated directory
+- Validate IAM catalog structure, size, documentation mappings, and transitional behavior parity
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,9 @@ npm run generate-iam-data -- --output-dir /tmp/expand-aws-iam-data
 ```
 
 Generation from one locked IAM-data package is byte-for-byte deterministic.
+Generated and tracked catalogs must also retain sorted, unique, well-formed
+actions, complete service documentation mappings, conservative count floors,
+and representative expansion and link parity.
 
 ## Preparing a Release
 

--- a/scripts/iam-data/catalog-parity.test.ts
+++ b/scripts/iam-data/catalog-parity.test.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { getActionDocUrl } from '../../src/docs.js';
+import { expandIamAction } from '../../src/expand.js';
+import { IAM_ACTIONS } from '../../src/iam-actions.js';
+import { SERVICE_DOC_SLUGS } from '../../src/service-doc-slugs.js';
+import { assertIamCatalog, LOCKED_CATALOG_MINIMUMS } from './catalog.js';
+import { readIamCatalog } from './generator.js';
+
+const repositoryRoot = resolve(import.meta.dirname, '../..');
+const lockedCatalog = readIamCatalog(
+  resolve(repositoryRoot, 'node_modules/@cloud-copilot/iam-data/data'),
+);
+const trackedCatalog = {
+  actions: IAM_ACTIONS,
+  serviceDocSlugs: SERVICE_DOC_SLUGS,
+};
+
+describe('IAM catalog shadow parity', () => {
+  it('validates tracked and locked catalogs against production floors', () => {
+    expect(() => assertIamCatalog(trackedCatalog, LOCKED_CATALOG_MINIMUMS)).not.toThrow();
+    expect(() => assertIamCatalog(lockedCatalog, LOCKED_CATALOG_MINIMUMS)).not.toThrow();
+  });
+
+  it.each([
+    's3:Get*Tagging',
+    'iam:GetRolePolicy',
+    'ec2:DescribeInstances',
+  ])('preserves representative expansion for %s', (pattern) => {
+    expect(expandIamAction(pattern, lockedCatalog.actions)).toEqual(expandIamAction(pattern));
+  });
+
+  it.each([
+    's3:GetObject',
+    'elasticfilesystem:DescribeFileSystems',
+    'sso:CreateApplication',
+  ])('preserves representative documentation links for %s', (action) => {
+    expect(getActionDocUrl(action, lockedCatalog.serviceDocSlugs)).toBe(getActionDocUrl(action));
+  });
+});

--- a/scripts/iam-data/catalog.test.ts
+++ b/scripts/iam-data/catalog.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertIamCatalog,
+  type IamCatalog,
+  LOCKED_CATALOG_MINIMUMS,
+} from './catalog.js';
+
+function catalog(overrides: Partial<IamCatalog> = {}): IamCatalog {
+  return {
+    actions: ['s3:GetObject', 's3:PutObject'],
+    serviceDocSlugs: { s3: 'amazons3' },
+    ...overrides,
+  };
+}
+
+describe('assertIamCatalog', () => {
+  it('accepts a sorted catalog with complete service documentation', () => {
+    expect(() => assertIamCatalog(catalog())).not.toThrow();
+    expect(() => assertIamCatalog(catalog({
+      actions: ['vpc-lattice:AssociateViaAWSService-EventsAndStates'],
+      serviceDocSlugs: { 'vpc-lattice': 'amazonvpclattice' },
+    }))).not.toThrow();
+  });
+
+  it('enforces minimum action and service counts', () => {
+    expect(() => assertIamCatalog(catalog(), { actionCount: 3, serviceCount: 1 })).toThrow(
+      'IAM catalog has 2 actions; expected at least 3',
+    );
+    expect(() => assertIamCatalog(catalog(), { actionCount: 2, serviceCount: 2 })).toThrow(
+      'IAM catalog has 1 services; expected at least 2',
+    );
+  });
+
+  it('rejects malformed, duplicate, and unsorted actions', () => {
+    expect(() => assertIamCatalog(catalog({ actions: ['not-an-action'] }))).toThrow(
+      'Invalid IAM action: not-an-action',
+    );
+    expect(() => assertIamCatalog(catalog({
+      actions: ['s3:GetObject', 's3:GetObject'],
+    }))).toThrow('Duplicate IAM action: s3:GetObject');
+    expect(() => assertIamCatalog(catalog({
+      actions: ['s3:PutObject', 's3:GetObject'],
+    }))).toThrow('IAM actions are not sorted: s3:PutObject before s3:GetObject');
+  });
+
+  it('rejects unsorted service prefixes and invalid slugs', () => {
+    expect(() => assertIamCatalog(catalog({
+      actions: ['ec2:DescribeInstances', 's3:GetObject'],
+      serviceDocSlugs: { s3: 'amazons3', ec2: 'amazonec2' },
+    }))).toThrow('IAM service prefixes are not sorted: s3');
+    expect(() => assertIamCatalog(catalog({
+      serviceDocSlugs: { s3: 'Amazon S3' },
+    }))).toThrow('Invalid IAM service documentation slug for s3: Amazon S3');
+    expect(() => assertIamCatalog(catalog({
+      serviceDocSlugs: { s3: undefined as unknown as string },
+    }))).toThrow('Invalid IAM service documentation slug for s3: <missing>');
+  });
+
+  it('rejects missing and extra service documentation mappings', () => {
+    expect(() => assertIamCatalog(catalog({
+      serviceDocSlugs: { ec2: 'amazonec2', s3: 'amazons3' },
+    }))).toThrow('IAM service documentation has no actions: ec2');
+    expect(() => assertIamCatalog(catalog({
+      actions: ['ec2:DescribeInstances', 's3:GetObject'],
+      serviceDocSlugs: { s3: 'amazons3' },
+    }))).toThrow('Missing IAM service documentation slug: ec2');
+  });
+
+  it('defines conservative locked-catalog floors', () => {
+    expect(LOCKED_CATALOG_MINIMUMS).toEqual({
+      actionCount: 20_000,
+      serviceCount: 400,
+    });
+  });
+});

--- a/scripts/iam-data/catalog.ts
+++ b/scripts/iam-data/catalog.ts
@@ -1,0 +1,69 @@
+export interface IamCatalog {
+  readonly actions: readonly string[];
+  readonly serviceDocSlugs: Readonly<Record<string, string>>;
+}
+
+export interface IamCatalogMinimums {
+  readonly actionCount: number;
+  readonly serviceCount: number;
+}
+
+export const LOCKED_CATALOG_MINIMUMS: IamCatalogMinimums = {
+  actionCount: 20_000,
+  serviceCount: 400,
+};
+
+const ACTION_PATTERN = /^[a-z0-9][a-z0-9-]*:[A-Za-z0-9][A-Za-z0-9-]*$/;
+const DOC_SLUG_PATTERN = /^[a-z0-9]+$/;
+
+export function assertIamCatalog(
+  catalog: IamCatalog,
+  minimums: IamCatalogMinimums = { actionCount: 1, serviceCount: 1 },
+): void {
+  if (catalog.actions.length < minimums.actionCount) {
+    throw new Error(
+      `IAM catalog has ${catalog.actions.length} actions; expected at least ${minimums.actionCount}`,
+    );
+  }
+
+  const actionSet = new Set<string>();
+  const actionServices = new Set<string>();
+  let previousAction: string | undefined;
+  for (const action of catalog.actions) {
+    if (!ACTION_PATTERN.test(action)) throw new Error(`Invalid IAM action: ${action}`);
+    if (actionSet.has(action)) throw new Error(`Duplicate IAM action: ${action}`);
+    if (previousAction !== undefined && previousAction > action) {
+      throw new Error(`IAM actions are not sorted: ${previousAction} before ${action}`);
+    }
+
+    actionSet.add(action);
+    actionServices.add(action.slice(0, action.indexOf(':')));
+    previousAction = action;
+  }
+
+  const servicePrefixes = Object.keys(catalog.serviceDocSlugs);
+  if (servicePrefixes.length < minimums.serviceCount) {
+    throw new Error(
+      `IAM catalog has ${servicePrefixes.length} services; expected at least ${minimums.serviceCount}`,
+    );
+  }
+  const sortedServicePrefixes = [...servicePrefixes].sort();
+  for (const [index, servicePrefix] of servicePrefixes.entries()) {
+    if (servicePrefix !== sortedServicePrefixes[index]) {
+      throw new Error(`IAM service prefixes are not sorted: ${servicePrefix}`);
+    }
+    const slug = catalog.serviceDocSlugs[servicePrefix];
+    if (slug === undefined || !DOC_SLUG_PATTERN.test(slug)) {
+      throw new Error(`Invalid IAM service documentation slug for ${servicePrefix}: ${slug ?? '<missing>'}`);
+    }
+    if (!actionServices.has(servicePrefix)) {
+      throw new Error(`IAM service documentation has no actions: ${servicePrefix}`);
+    }
+  }
+
+  for (const servicePrefix of actionServices) {
+    if (!Object.hasOwn(catalog.serviceDocSlugs, servicePrefix)) {
+      throw new Error(`Missing IAM service documentation slug: ${servicePrefix}`);
+    }
+  }
+}

--- a/scripts/iam-data/generator.ts
+++ b/scripts/iam-data/generator.ts
@@ -9,6 +9,8 @@ import {
 import { tmpdir } from 'node:os';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 
+import { assertIamCatalog, type IamCatalog } from './catalog.js';
+
 interface IamDataAction {
   readonly name: string;
 }
@@ -114,31 +116,39 @@ function validateOutputFiles(paths: readonly string[]): void {
   }
 }
 
+export function readIamCatalog(dataDirectory: string): IamCatalog {
+  const resolvedDataDirectory = resolve(dataDirectory);
+  const actionsDirectory = join(resolvedDataDirectory, 'actions');
+  const serviceNamesPath = join(resolvedDataDirectory, 'serviceNames.json');
+  const servicePrefixes = readServicePrefixes(actionsDirectory);
+  const actions = readAllActions(actionsDirectory, servicePrefixes);
+  const serviceNames = JSON.parse(readFileSync(serviceNamesPath, 'utf8')) as Record<string, string>;
+  const serviceDocSlugs = generateServiceDocSlugs(servicePrefixes, serviceNames);
+  const catalog = { actions, serviceDocSlugs };
+  assertIamCatalog(catalog);
+  return catalog;
+}
+
 export function generateIamData(options: GenerateIamDataOptions): IamDataGenerationResult {
   const dataDirectory = resolve(options.dataDirectory);
-  const actionsDirectory = join(dataDirectory, 'actions');
-  const serviceNamesPath = join(dataDirectory, 'serviceNames.json');
   const outputDirectory = validateGeneratorOutputDirectory(
     options.repositoryRoot,
     options.outputDirectory,
   );
 
-  const servicePrefixes = readServicePrefixes(actionsDirectory);
-  const allActions = readAllActions(actionsDirectory, servicePrefixes);
-  const serviceNames = JSON.parse(readFileSync(serviceNamesPath, 'utf8')) as Record<string, string>;
-  const serviceDocSlugs = generateServiceDocSlugs(servicePrefixes, serviceNames);
+  const catalog = readIamCatalog(dataDirectory);
   const actionsOutputPath = join(outputDirectory, 'iam-actions.ts');
   const serviceDocSlugsOutputPath = join(outputDirectory, 'service-doc-slugs.ts');
 
   const actionsOutput = `// Auto-generated - do not edit
 // Run: npm run generate-iam-data
 
-export const IAM_ACTIONS: readonly string[] = ${JSON.stringify(allActions, null, 2)};
+export const IAM_ACTIONS: readonly string[] = ${JSON.stringify(catalog.actions, null, 2)};
 `;
   const serviceDocSlugsOutput = `// Auto-generated - do not edit
 // Run: npm run generate-iam-data
 
-export const SERVICE_DOC_SLUGS: Readonly<Record<string, string>> = ${JSON.stringify(serviceDocSlugs, null, 2)};
+export const SERVICE_DOC_SLUGS: Readonly<Record<string, string>> = ${JSON.stringify(catalog.serviceDocSlugs, null, 2)};
 `;
 
   mkdirSync(outputDirectory, { recursive: true });
@@ -147,7 +157,7 @@ export const SERVICE_DOC_SLUGS: Readonly<Record<string, string>> = ${JSON.string
   writeFileSync(serviceDocSlugsOutputPath, serviceDocSlugsOutput, 'utf8');
 
   return {
-    actionCount: allActions.length,
-    serviceCount: servicePrefixes.length,
+    actionCount: catalog.actions.length,
+    serviceCount: Object.keys(catalog.serviceDocSlugs).length,
   };
 }

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -1,10 +1,13 @@
 import { SERVICE_DOC_SLUGS } from './service-doc-slugs.js';
 
-export function getActionDocUrl(action: string): string | null {
+export function getActionDocUrl(
+  action: string,
+  serviceDocSlugs: Readonly<Record<string, string>> = SERVICE_DOC_SLUGS,
+): string | null {
   const [service, actionName] = action.split(':');
   if (!service || !actionName) return null;
 
-  const slug = SERVICE_DOC_SLUGS[service.toLowerCase()];
+  const slug = serviceDocSlugs[service.toLowerCase()];
   if (!slug) return null;
 
   // Use text fragment only; avoids some pages overriding section hash navigation.

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -1,6 +1,9 @@
 import { IAM_ACTIONS } from './iam-actions.js';
 
-export function expandIamAction(pattern: string): string[] {
+export function expandIamAction(
+  pattern: string,
+  iamActions: readonly string[] = IAM_ACTIONS,
+): string[] {
   const normalized = pattern
     .trim()
     .replace(/\u2217/g, '*')  // ∗ (unicode asterisk operator)
@@ -14,7 +17,7 @@ export function expandIamAction(pattern: string): string[] {
 
   try {
     const regex = new RegExp('^' + regexPattern + '$', 'i');
-    return IAM_ACTIONS.filter((action) => regex.test(action));
+    return iamActions.filter((action) => regex.test(action));
   } catch {
     return [];
   }


### PR DESCRIPTION
Validates tracked and locked IAM catalogs for structure, sorting, uniqueness, count floors, and documentation coverage.
Runs locked data in shadow against representative current expansions and links without changing runtime data.