### PR TITLE
Build from locked IAM data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 coverage/
 node_modules/
+.build/
 
 # Build artifacts (only keep dist/index.js)
 dist/*.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Smoke-test the compiled action without changing the committed runtime bundle
 - Generate IAM catalog modules deterministically into an explicit validated directory
 - Validate IAM catalog structure, size, documentation mappings, and transitional behavior parity
+- Build the action bundle from lock-selected IAM data in an ignored workspace
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,15 @@ same strict TypeScript configuration.
 `npm run docs:check` keeps README input names, defaults, example inputs, and the
 runtime entry aligned with `action.yml` and `package.json`.
 
-`npm run build` compiles through the repository-local `ncc` executable in a
-temporary directory before replacing `dist/index.js`. `npm run build:check`
-rebuilds twice and compares both results with the committed bundle without
-modifying `dist/`. `npm run build:smoke` builds temporarily, executes the entry
-declared by `action.yml` with a synthetic non-PR event, and cleans up without
-changing `dist/`.
+Each build copies the TypeScript source into an ignored workspace, replaces the
+tracked IAM modules there with data from the lock-selected
+`@cloud-copilot/iam-data` package, validates the catalog, and compiles through
+the repository-local `ncc` executable. The workspace is removed afterward.
+`npm run build` replaces `dist/index.js` only after that isolated build succeeds.
+`npm run build:check` rebuilds twice and compares both results with the
+committed bundle without modifying `dist/`. `npm run build:smoke` builds
+temporarily, executes the entry declared by `action.yml` with a synthetic
+non-PR event, and cleans up without changing `dist/`.
 
 ## Pull Requests
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,27 +9,30 @@ import {
   writeCommittedBundle,
 } from './release/build.js';
 import { smokeTestAction } from './release/smoke.js';
+import { withGeneratedBuildWorkspace } from './release/workspace.js';
 
 const repositoryRoot = resolve(import.meta.dirname, '..');
 const nccCli = resolve(repositoryRoot, 'node_modules/@vercel/ncc/dist/ncc/cli.js');
 
 const compile: BundleCompiler = (outputDirectory) => {
-  const result = spawnSync(process.execPath, [
-    nccCli,
-    'build',
-    'src/index.ts',
-    '-o',
-    outputDirectory,
-    '--no-source-map-register',
-    '--license',
-    'licenses.txt',
-  ], {
-    cwd: repositoryRoot,
-    stdio: 'inherit',
-  });
+  withGeneratedBuildWorkspace(repositoryRoot, (workspace) => {
+    const result = spawnSync(process.execPath, [
+      nccCli,
+      'build',
+      workspace.entryPoint,
+      '-o',
+      outputDirectory,
+      '--no-source-map-register',
+      '--license',
+      'licenses.txt',
+    ], {
+      cwd: repositoryRoot,
+      stdio: 'inherit',
+    });
 
-  if (result.error !== undefined) throw result.error;
-  if (result.status !== 0) throw new Error(`ncc failed with exit status ${result.status ?? 1}`);
+    if (result.error !== undefined) throw result.error;
+    if (result.status !== 0) throw new Error(`ncc failed with exit status ${result.status ?? 1}`);
+  });
 };
 
 try {

--- a/scripts/iam-data/generator.ts
+++ b/scripts/iam-data/generator.ts
@@ -9,7 +9,11 @@ import {
 import { tmpdir } from 'node:os';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 
-import { assertIamCatalog, type IamCatalog } from './catalog.js';
+import {
+  assertIamCatalog,
+  type IamCatalog,
+  type IamCatalogMinimums,
+} from './catalog.js';
 
 interface IamDataAction {
   readonly name: string;
@@ -19,6 +23,7 @@ export interface GenerateIamDataOptions {
   readonly dataDirectory: string;
   readonly outputDirectory: string;
   readonly repositoryRoot: string;
+  readonly minimums?: IamCatalogMinimums;
 }
 
 export interface IamDataGenerationResult {
@@ -116,7 +121,10 @@ function validateOutputFiles(paths: readonly string[]): void {
   }
 }
 
-export function readIamCatalog(dataDirectory: string): IamCatalog {
+export function readIamCatalog(
+  dataDirectory: string,
+  minimums?: IamCatalogMinimums,
+): IamCatalog {
   const resolvedDataDirectory = resolve(dataDirectory);
   const actionsDirectory = join(resolvedDataDirectory, 'actions');
   const serviceNamesPath = join(resolvedDataDirectory, 'serviceNames.json');
@@ -125,7 +133,7 @@ export function readIamCatalog(dataDirectory: string): IamCatalog {
   const serviceNames = JSON.parse(readFileSync(serviceNamesPath, 'utf8')) as Record<string, string>;
   const serviceDocSlugs = generateServiceDocSlugs(servicePrefixes, serviceNames);
   const catalog = { actions, serviceDocSlugs };
-  assertIamCatalog(catalog);
+  assertIamCatalog(catalog, minimums);
   return catalog;
 }
 
@@ -136,7 +144,7 @@ export function generateIamData(options: GenerateIamDataOptions): IamDataGenerat
     options.outputDirectory,
   );
 
-  const catalog = readIamCatalog(dataDirectory);
+  const catalog = readIamCatalog(dataDirectory, options.minimums);
   const actionsOutputPath = join(outputDirectory, 'iam-actions.ts');
   const serviceDocSlugsOutputPath = join(outputDirectory, 'service-doc-slugs.ts');
 

--- a/scripts/release/workspace.test.ts
+++ b/scripts/release/workspace.test.ts
@@ -1,0 +1,110 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { LOCKED_CATALOG_MINIMUMS } from '../iam-data/catalog.js';
+import { withGeneratedBuildWorkspace } from './workspace.js';
+
+function withFixture<T>(useFixture: (directory: string) => T): T {
+  const directory = mkdtempSync(join(tmpdir(), 'build-workspace-test-'));
+  try {
+    return useFixture(directory);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function writeFile(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+function createRepository(directory: string): string {
+  const repositoryRoot = join(directory, 'repository');
+  writeFile(join(repositoryRoot, 'src/index.ts'), "import './iam-actions.js';\n");
+  writeFile(join(repositoryRoot, 'src/helper.ts'), 'export const helper = true;\n');
+  writeFile(join(repositoryRoot, 'src/iam-actions.ts'), 'tracked actions sentinel\n');
+  writeFile(join(repositoryRoot, 'src/service-doc-slugs.ts'), 'tracked slugs sentinel\n');
+  return repositoryRoot;
+}
+
+describe('withGeneratedBuildWorkspace', () => {
+  it('replaces tracked catalog modules with data from the locked package', () => {
+    withFixture((directory) => {
+      const repositoryRoot = createRepository(directory);
+      let workspaceRoot = '';
+
+      withGeneratedBuildWorkspace(repositoryRoot, (workspace) => {
+        workspaceRoot = workspace.rootDirectory;
+        expect(workspace.catalog.actionCount).toBeGreaterThanOrEqual(
+          LOCKED_CATALOG_MINIMUMS.actionCount,
+        );
+        expect(workspace.catalog.serviceCount).toBeGreaterThanOrEqual(
+          LOCKED_CATALOG_MINIMUMS.serviceCount,
+        );
+        expect(readFileSync(join(workspace.rootDirectory, 'src/helper.ts'), 'utf8')).toBe(
+          'export const helper = true;\n',
+        );
+        expect(readFileSync(join(workspace.rootDirectory, 'src/iam-actions.ts'), 'utf8'))
+          .not.toContain('tracked actions sentinel');
+        expect(readFileSync(join(workspace.rootDirectory, 'src/service-doc-slugs.ts'), 'utf8'))
+          .not.toContain('tracked slugs sentinel');
+      });
+
+      expect(existsSync(workspaceRoot)).toBe(false);
+      expect(readdirSync(join(repositoryRoot, '.build'))).toEqual([]);
+    });
+  });
+
+  it('cleans the workspace when its consumer fails', () => {
+    withFixture((directory) => {
+      const repositoryRoot = createRepository(directory);
+      let workspaceRoot = '';
+
+      expect(() => withGeneratedBuildWorkspace(repositoryRoot, (workspace) => {
+        workspaceRoot = workspace.rootDirectory;
+        throw new Error('compiler failed');
+      })).toThrow('compiler failed');
+
+      expect(existsSync(workspaceRoot)).toBe(false);
+    });
+  });
+
+  it('refuses an existing workspace without deleting it', () => {
+    withFixture((directory) => {
+      const repositoryRoot = createRepository(directory);
+      const preservedFile = join(repositoryRoot, '.build/workspace/preserved');
+      writeFile(preservedFile, 'keep me');
+
+      expect(() => withGeneratedBuildWorkspace(repositoryRoot, () => undefined)).toThrow(
+        `Build workspace already exists: ${join(repositoryRoot, '.build/workspace')}`,
+      );
+      expect(readFileSync(preservedFile, 'utf8')).toBe('keep me');
+    });
+  });
+
+  it('rejects symbolic links in copied source and cleans up', () => {
+    withFixture((directory) => {
+      const repositoryRoot = createRepository(directory);
+      const linkedSource = join(repositoryRoot, 'linked-source.ts');
+      writeFile(linkedSource, 'outside source\n');
+      symlinkSync(linkedSource, join(repositoryRoot, 'src/linked.ts'));
+
+      expect(() => withGeneratedBuildWorkspace(repositoryRoot, () => undefined)).toThrow(
+        'Build source must not contain symbolic links: src/linked.ts',
+      );
+      expect(existsSync(join(repositoryRoot, '.build/workspace'))).toBe(false);
+      expect(readFileSync(linkedSource, 'utf8')).toBe('outside source\n');
+    });
+  });
+});

--- a/scripts/release/workspace.test.ts
+++ b/scripts/release/workspace.test.ts
@@ -8,6 +8,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -32,10 +33,19 @@ function writeFile(path: string, contents: string): void {
 function createRepository(directory: string): string {
   const repositoryRoot = join(directory, 'repository');
   writeFile(join(repositoryRoot, 'src/index.ts'), "import './iam-actions.js';\n");
-  writeFile(join(repositoryRoot, 'src/helper.ts'), 'export const helper = true;\n');
+  writeFile(join(repositoryRoot, 'src/nested/helper.ts'), 'export const helper = true;\n');
   writeFile(join(repositoryRoot, 'src/iam-actions.ts'), 'tracked actions sentinel\n');
   writeFile(join(repositoryRoot, 'src/service-doc-slugs.ts'), 'tracked slugs sentinel\n');
   return repositoryRoot;
+}
+
+function createDataFixture(directory: string): string {
+  const dataDirectory = join(directory, 'iam-data');
+  writeFile(join(dataDirectory, 'actions/s3.json'), JSON.stringify({
+    getObject: { name: 'GetObject' },
+  }));
+  writeFile(join(dataDirectory, 'serviceNames.json'), JSON.stringify({ s3: 'Amazon S3' }));
+  return dataDirectory;
 }
 
 describe('withGeneratedBuildWorkspace', () => {
@@ -52,7 +62,7 @@ describe('withGeneratedBuildWorkspace', () => {
         expect(workspace.catalog.serviceCount).toBeGreaterThanOrEqual(
           LOCKED_CATALOG_MINIMUMS.serviceCount,
         );
-        expect(readFileSync(join(workspace.rootDirectory, 'src/helper.ts'), 'utf8')).toBe(
+        expect(readFileSync(join(workspace.rootDirectory, 'src/nested/helper.ts'), 'utf8')).toBe(
           'export const helper = true;\n',
         );
         expect(readFileSync(join(workspace.rootDirectory, 'src/iam-actions.ts'), 'utf8'))
@@ -69,12 +79,15 @@ describe('withGeneratedBuildWorkspace', () => {
   it('cleans the workspace when its consumer fails', () => {
     withFixture((directory) => {
       const repositoryRoot = createRepository(directory);
+      const dataDirectory = createDataFixture(directory);
       let workspaceRoot = '';
 
       expect(() => withGeneratedBuildWorkspace(repositoryRoot, (workspace) => {
         workspaceRoot = workspace.rootDirectory;
         throw new Error('compiler failed');
-      })).toThrow('compiler failed');
+      }, { dataDirectory, minimums: { actionCount: 1, serviceCount: 1 } })).toThrow(
+        'compiler failed',
+      );
 
       expect(existsSync(workspaceRoot)).toBe(false);
     });
@@ -105,6 +118,60 @@ describe('withGeneratedBuildWorkspace', () => {
       );
       expect(existsSync(join(repositoryRoot, '.build/workspace'))).toBe(false);
       expect(readFileSync(linkedSource, 'utf8')).toBe('outside source\n');
+    });
+  });
+
+  it.each(['file', 'symbolic link'] as const)('rejects a %s at the build root', (kind) => {
+    withFixture((directory) => {
+      const repositoryRoot = createRepository(directory);
+      const buildRoot = join(repositoryRoot, '.build');
+      if (kind === 'file') {
+        writeFile(buildRoot, 'not a directory');
+      } else {
+        const linkedDirectory = join(repositoryRoot, 'linked-build-root');
+        mkdirSync(linkedDirectory);
+        writeFile(join(linkedDirectory, 'preserved'), 'keep me');
+        symlinkSync(linkedDirectory, buildRoot);
+      }
+
+      expect(() => withGeneratedBuildWorkspace(repositoryRoot, () => undefined)).toThrow(
+        `Build root must be a regular directory: ${buildRoot}`,
+      );
+      if (kind === 'symbolic link') {
+        expect(readFileSync(join(repositoryRoot, 'linked-build-root/preserved'), 'utf8')).toBe(
+          'keep me',
+        );
+      }
+    });
+  });
+
+  it.each(['missing', 'directory'] as const)('rejects a %s entry point', (kind) => {
+    withFixture((directory) => {
+      const repositoryRoot = createRepository(directory);
+      const dataDirectory = createDataFixture(directory);
+      const entryPoint = join(repositoryRoot, 'src/index.ts');
+      rmSync(entryPoint);
+      if (kind === 'directory') mkdirSync(entryPoint);
+
+      expect(() => withGeneratedBuildWorkspace(
+        repositoryRoot,
+        () => undefined,
+        { dataDirectory, minimums: { actionCount: 1, serviceCount: 1 } },
+      )).toThrow('Build source is missing src/index.ts');
+      expect(existsSync(join(repositoryRoot, '.build/workspace'))).toBe(false);
+    });
+  });
+
+  it('rejects special filesystem entries in source without blocking', () => {
+    withFixture((directory) => {
+      const repositoryRoot = createRepository(directory);
+      const fifoPath = join(repositoryRoot, 'src/input.fifo');
+      execFileSync('mkfifo', [fifoPath]);
+
+      expect(() => withGeneratedBuildWorkspace(repositoryRoot, () => undefined)).toThrow(
+        'Build source contains an unsupported entry: src/input.fifo',
+      );
+      expect(existsSync(join(repositoryRoot, '.build/workspace'))).toBe(false);
     });
   });
 });

--- a/scripts/release/workspace.ts
+++ b/scripts/release/workspace.ts
@@ -1,0 +1,112 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
+import { dirname, join, posix, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  LOCKED_CATALOG_MINIMUMS,
+  type IamCatalogMinimums,
+} from '../iam-data/catalog.js';
+import {
+  generateIamData,
+  type IamDataGenerationResult,
+} from '../iam-data/generator.js';
+
+const GENERATED_CATALOG_MODULES = new Set([
+  'iam-actions.ts',
+  'service-doc-slugs.ts',
+]);
+const LOCKED_PACKAGE_ENTRY = fileURLToPath(import.meta.resolve('@cloud-copilot/iam-data'));
+const LOCKED_DATA_DIRECTORY = resolve(dirname(LOCKED_PACKAGE_ENTRY), '../../data');
+
+export interface GeneratedBuildWorkspace {
+  readonly rootDirectory: string;
+  readonly entryPoint: string;
+  readonly catalog: IamDataGenerationResult;
+}
+
+export interface BuildWorkspaceOptions {
+  readonly dataDirectory?: string;
+  readonly minimums?: IamCatalogMinimums;
+}
+
+function assertRegularDirectory(directory: string, label: string): void {
+  const status = lstatSync(directory);
+  if (status.isSymbolicLink() || !status.isDirectory()) {
+    throw new Error(`${label} must be a regular directory: ${directory}`);
+  }
+}
+
+function copySourceTree(
+  sourceDirectory: string,
+  destinationDirectory: string,
+  relativeDirectory = '',
+): void {
+  const currentSource = join(sourceDirectory, relativeDirectory);
+  const currentDestination = join(destinationDirectory, relativeDirectory);
+  mkdirSync(currentDestination, { recursive: true });
+
+  for (const entry of readdirSync(currentSource, { withFileTypes: true })) {
+    const relativePath = posix.join(relativeDirectory, entry.name);
+    if (relativeDirectory === '' && GENERATED_CATALOG_MODULES.has(entry.name)) continue;
+
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Build source must not contain symbolic links: src/${relativePath}`);
+    }
+    if (entry.isDirectory()) {
+      copySourceTree(sourceDirectory, destinationDirectory, relativePath);
+    } else if (entry.isFile()) {
+      copyFileSync(join(sourceDirectory, relativePath), join(destinationDirectory, relativePath));
+    } else {
+      throw new Error(`Build source contains an unsupported entry: src/${relativePath}`);
+    }
+  }
+}
+
+export function withGeneratedBuildWorkspace<T>(
+  repositoryRoot: string,
+  useWorkspace: (workspace: GeneratedBuildWorkspace) => T,
+  options: BuildWorkspaceOptions = {},
+): T {
+  const resolvedRepository = resolve(repositoryRoot);
+  const sourceDirectory = join(resolvedRepository, 'src');
+  assertRegularDirectory(sourceDirectory, 'Build source');
+
+  const buildRoot = join(resolvedRepository, '.build');
+  if (existsSync(buildRoot)) {
+    assertRegularDirectory(buildRoot, 'Build root');
+  } else {
+    mkdirSync(buildRoot);
+  }
+
+  const workspaceRoot = join(buildRoot, 'workspace');
+  if (existsSync(workspaceRoot)) {
+    throw new Error(`Build workspace already exists: ${workspaceRoot}`);
+  }
+
+  const workspaceSource = join(workspaceRoot, 'src');
+  mkdirSync(workspaceRoot);
+  try {
+    copySourceTree(sourceDirectory, workspaceSource);
+    const catalog = generateIamData({
+      dataDirectory: options.dataDirectory ?? LOCKED_DATA_DIRECTORY,
+      outputDirectory: workspaceSource,
+      repositoryRoot: resolvedRepository,
+      minimums: options.minimums ?? LOCKED_CATALOG_MINIMUMS,
+    });
+    const entryPoint = join(workspaceSource, 'index.ts');
+    if (!existsSync(entryPoint) || !lstatSync(entryPoint).isFile()) {
+      throw new Error('Build source is missing src/index.ts');
+    }
+
+    return useWorkspace({ rootDirectory: workspaceRoot, entryPoint, catalog });
+  } finally {
+    rmSync(workspaceRoot, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
Build the action bundle from validated IAM data selected by `package-lock.json`.

Keeps tracked catalog modules as temporary parity fixtures and cleans isolated build workspaces without touching `dist/`