### PR TITLE
Reinstall and report selected IAM data

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -54,6 +54,16 @@ jobs:
       - name: Select latest IAM data
         run: npm run release:select-iam-data
 
+      - name: Reinstall selected dependencies
+        run: npm ci
+
+      - name: Report selected IAM data
+        id: iam_data
+        run: npm run release:report-iam-data
+
+      - name: Show IAM dependency changes
+        run: git diff -- package.json package-lock.json
+
       - name: Lint
         run: npm run lint
 
@@ -86,9 +96,13 @@ jobs:
       - name: Create or update the release preparation branch
         env:
           GH_TOKEN: ${{ secrets.IAM_UPDATE_PAT }}
+          IAM_ACTION_COUNT: ${{ steps.iam_data.outputs.action_count }}
+          IAM_DATA_VERSION: ${{ steps.iam_data.outputs.version }}
+          IAM_SERVICE_COUNT: ${{ steps.iam_data.outputs.service_count }}
           VERSION: ${{ inputs.version }}
         run: |
           BRANCH="release-candidate/v${VERSION}"
+          BODY="Selects IAM data ${IAM_DATA_VERSION} with ${IAM_ACTION_COUNT} actions across ${IAM_SERVICE_COUNT} services, generates the release bundle on Ubuntu, and updates package metadata for v${VERSION}."
           git switch -c "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -104,6 +118,7 @@ jobs:
 
           pr_number="$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number // empty')"
           if [[ -n "$pr_number" ]]; then
+            gh pr edit "$pr_number" --body "$BODY"
             echo "Updated existing release preparation PR #$pr_number"
             exit 0
           fi
@@ -112,4 +127,4 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "Prepare v${VERSION} release" \
-            --body "Selects and locks the latest IAM data, generates the release bundle on Ubuntu, updates package metadata for v${VERSION}, and prepares the exact commit that should be signed and tagged for release."
+            --body "$BODY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate IAM catalog structure, size, documentation mappings, and transitional behavior parity
 - Build the action bundle from lock-selected IAM data in an ignored workspace
 - Select and lock IAM data as part of release preparation
+- Reinstall and report the selected IAM catalog before release builds
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,9 +93,10 @@ actions, complete service documentation mappings, conservative count floors,
 and representative expansion and link parity.
 
 Release preparation selects the latest numeric IAM-data version, rejects
-downgrades, records the selected version exactly in `package.json` and
-`package-lock.json`, and runs the release checks and bundle build with that
-installed package.
+downgrades, and records the selected version exactly in `package.json` and
+`package-lock.json`. It then reinstalls with `npm ci`, verifies the installed
+package against the lockfile, validates and reports catalog counts, and runs the
+release checks and bundle build with that clean installation.
 
 ## Preparing a Release
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint .",
     "lint:md": "markdownlint '**/*.md' --ignore node_modules",
     "release": "tsx scripts/release.ts",
+    "release:report-iam-data": "tsx scripts/report-iam-data.ts",
     "release:select-iam-data": "tsx scripts/select-iam-data.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/release/iam-data-report.test.ts
+++ b/scripts/release/iam-data-report.test.ts
@@ -1,0 +1,186 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { LOCKED_CATALOG_MINIMUMS } from '../iam-data/catalog.js';
+import {
+  createIamDataReport,
+  type IamDataReport,
+  writeIamDataReport,
+} from './iam-data-report.js';
+import { IAM_DATA_PACKAGE } from './iam-data.js';
+
+function withFixture<T>(useFixture: (directory: string) => T): T {
+  const directory = mkdtempSync(join(tmpdir(), 'iam-data-report-test-'));
+  try {
+    return useFixture(directory);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function writeFile(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+function writePackageState(
+  directory: string,
+  lockedVersion: string,
+  installedVersion = lockedVersion,
+  manifestVersion = lockedVersion,
+): string {
+  const installedPackage = join(directory, 'node_modules', IAM_DATA_PACKAGE);
+  writeFile(join(directory, 'package.json'), JSON.stringify({
+    devDependencies: { [IAM_DATA_PACKAGE]: manifestVersion },
+  }));
+  writeFile(join(directory, 'package-lock.json'), JSON.stringify({
+    packages: {
+      '': { devDependencies: { [IAM_DATA_PACKAGE]: manifestVersion } },
+      [`node_modules/${IAM_DATA_PACKAGE}`]: { version: lockedVersion },
+    },
+  }));
+  writeFile(join(installedPackage, 'package.json'), JSON.stringify({ version: installedVersion }));
+  return installedPackage;
+}
+
+function writeSmallCatalog(installedPackage: string): void {
+  writeFile(join(installedPackage, 'data/actions/s3.json'), JSON.stringify({
+    getObject: { name: 'GetObject' },
+  }));
+  writeFile(
+    join(installedPackage, 'data/serviceNames.json'),
+    JSON.stringify({ s3: 'Amazon S3' }),
+  );
+}
+
+describe('createIamDataReport', () => {
+  it('reports the real lock-selected catalog against production floors', () => {
+    withFixture((directory) => {
+      const repositoryRoot = resolve(import.meta.dirname, '../..');
+      const realInstalledPackage = join(repositoryRoot, 'node_modules', IAM_DATA_PACKAGE);
+      const installedMetadata = JSON.parse(
+        readFileSync(join(realInstalledPackage, 'package.json'), 'utf8'),
+      ) as { version: string };
+      const fixturePackage = writePackageState(directory, installedMetadata.version);
+      symlinkSync(join(realInstalledPackage, 'data'), join(fixturePackage, 'data'));
+
+      const report = createIamDataReport(directory);
+
+      expect(report.version).toBe(installedMetadata.version);
+      expect(report.actionCount).toBeGreaterThanOrEqual(LOCKED_CATALOG_MINIMUMS.actionCount);
+      expect(report.serviceCount).toBeGreaterThanOrEqual(LOCKED_CATALOG_MINIMUMS.serviceCount);
+    });
+  });
+
+  it('reports a valid installed fixture catalog', () => {
+    withFixture((directory) => {
+      const installedPackage = writePackageState(directory, '0.21.2');
+      writeSmallCatalog(installedPackage);
+
+      expect(createIamDataReport(
+        directory,
+        { actionCount: 1, serviceCount: 1 },
+      )).toEqual({
+        actionCount: 1,
+        serviceCount: 1,
+        version: '0.21.2',
+      });
+    });
+  });
+
+  it('rejects disagreement with the installed package', () => {
+    withFixture((directory) => {
+      writePackageState(directory, '0.21.2', '0.21.1');
+
+      expect(() => createIamDataReport(
+        directory,
+        { actionCount: 1, serviceCount: 1 },
+      )).toThrow(
+        `Installed ${IAM_DATA_PACKAGE} version 0.21.1 does not match locked version 0.21.2`,
+      );
+    });
+  });
+
+  it('rejects missing installed version metadata', () => {
+    withFixture((directory) => {
+      const installedPackage = writePackageState(directory, '0.21.2');
+      writeFile(join(installedPackage, 'package.json'), '{}');
+
+      expect(() => createIamDataReport(
+        directory,
+        { actionCount: 1, serviceCount: 1 },
+      )).toThrow(
+        `Installed ${IAM_DATA_PACKAGE} version <missing> does not match locked version 0.21.2`,
+      );
+    });
+  });
+
+  it('rejects package metadata disagreement before reading the catalog', () => {
+    withFixture((directory) => {
+      writePackageState(directory, '0.21.2', '0.21.2', '^0.21.1');
+
+      expect(() => createIamDataReport(
+        directory,
+        { actionCount: 1, serviceCount: 1 },
+      )).toThrow(`npm did not record ${IAM_DATA_PACKAGE}@0.21.2 exactly`);
+    });
+  });
+
+  it('enforces catalog production floors', () => {
+    withFixture((directory) => {
+      const installedPackage = writePackageState(directory, '0.21.2');
+      writeSmallCatalog(installedPackage);
+
+      expect(() => createIamDataReport(
+        directory,
+        { actionCount: 2, serviceCount: 1 },
+      )).toThrow('IAM catalog has 1 actions; expected at least 2');
+    });
+  });
+});
+
+describe('writeIamDataReport', () => {
+  const report: IamDataReport = {
+    actionCount: 21_234,
+    serviceCount: 456,
+    version: '0.21.202608201',
+  };
+
+  it('appends GitHub outputs and a readable step summary', () => {
+    withFixture((directory) => {
+      const outputPath = join(directory, 'output');
+      const summaryPath = join(directory, 'summary');
+      writeFile(outputPath, 'existing=true\n');
+      writeFile(summaryPath, 'Existing summary\n\n');
+
+      writeIamDataReport(report, {
+        githubOutputPath: outputPath,
+        githubSummaryPath: summaryPath,
+      });
+
+      expect(readFileSync(outputPath, 'utf8')).toBe([
+        'existing=true',
+        'version=0.21.202608201',
+        'action_count=21234',
+        'service_count=456',
+        '',
+      ].join('\n'));
+      expect(readFileSync(summaryPath, 'utf8')).toContain(
+        '| @cloud-copilot/iam-data | 0.21.202608201 | 21234 | 456 |',
+      );
+    });
+  });
+
+  it('allows local reporting without GitHub destination files', () => {
+    expect(() => writeIamDataReport(report, {})).not.toThrow();
+  });
+});

--- a/scripts/release/iam-data-report.ts
+++ b/scripts/release/iam-data-report.ts
@@ -1,0 +1,86 @@
+import { appendFileSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import {
+  LOCKED_CATALOG_MINIMUMS,
+  type IamCatalogMinimums,
+} from '../iam-data/catalog.js';
+import { readIamCatalog } from '../iam-data/generator.js';
+import {
+  assertRecordedIamDataVersion,
+  IAM_DATA_PACKAGE,
+  installedIamDataDirectory,
+  lockedIamDataVersion,
+} from './iam-data.js';
+
+interface InstalledPackageJson {
+  readonly version?: string;
+}
+
+export interface IamDataReport {
+  readonly actionCount: number;
+  readonly serviceCount: number;
+  readonly version: string;
+}
+
+export interface IamDataReportDestinations {
+  readonly githubOutputPath?: string;
+  readonly githubSummaryPath?: string;
+}
+
+export function createIamDataReport(
+  repositoryRoot: string,
+  minimums: IamCatalogMinimums = LOCKED_CATALOG_MINIMUMS,
+): IamDataReport {
+  const resolvedRepository = resolve(repositoryRoot);
+  const lockedVersion = lockedIamDataVersion(resolvedRepository);
+  assertRecordedIamDataVersion(resolvedRepository, lockedVersion);
+
+  const installedPackagePath = join(
+    resolvedRepository,
+    'node_modules',
+    IAM_DATA_PACKAGE,
+    'package.json',
+  );
+  const installedPackage = JSON.parse(
+    readFileSync(installedPackagePath, 'utf8'),
+  ) as InstalledPackageJson;
+  if (installedPackage.version !== lockedVersion) {
+    throw new Error(
+      `Installed ${IAM_DATA_PACKAGE} version ${installedPackage.version ?? '<missing>'} ` +
+      `does not match locked version ${lockedVersion}`,
+    );
+  }
+
+  const catalog = readIamCatalog(installedIamDataDirectory(resolvedRepository), minimums);
+  return {
+    actionCount: catalog.actions.length,
+    serviceCount: Object.keys(catalog.serviceDocSlugs).length,
+    version: lockedVersion,
+  };
+}
+
+export function writeIamDataReport(
+  report: IamDataReport,
+  destinations: IamDataReportDestinations,
+): void {
+  if (destinations.githubOutputPath !== undefined) {
+    appendFileSync(
+      destinations.githubOutputPath,
+      `version=${report.version}\naction_count=${report.actionCount}\nservice_count=${report.serviceCount}\n`,
+    );
+  }
+  if (destinations.githubSummaryPath !== undefined) {
+    appendFileSync(
+      destinations.githubSummaryPath,
+      [
+        '## Selected IAM catalog',
+        '',
+        '| Package | Version | Actions | Services |',
+        '| --- | --- | ---: | ---: |',
+        `| ${IAM_DATA_PACKAGE} | ${report.version} | ${report.actionCount} | ${report.serviceCount} |`,
+        '',
+      ].join('\n'),
+    );
+  }
+}

--- a/scripts/release/iam-data.test.ts
+++ b/scripts/release/iam-data.test.ts
@@ -106,7 +106,8 @@ describe('selectIamDataVersion', () => {
       });
       expect(calls).toEqual([
         `npm view ${IAM_DATA_PACKAGE} version`,
-        `npm install --save-dev --save-exact ${IAM_DATA_PACKAGE}@0.21.202608201`,
+        `npm install --save-dev --save-exact --package-lock-only ` +
+        `${IAM_DATA_PACKAGE}@0.21.202608201`,
       ]);
       expect(JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8')))
         .toMatchObject({ devDependencies: { [IAM_DATA_PACKAGE]: '0.21.202608201' } });
@@ -128,7 +129,7 @@ describe('selectIamDataVersion', () => {
         selectedVersion: '0.21.2',
       });
       expect(calls).toEqual([
-        `npm install --save-dev --save-exact ${IAM_DATA_PACKAGE}@0.21.2`,
+        `npm install --save-dev --save-exact --package-lock-only ${IAM_DATA_PACKAGE}@0.21.2`,
       ]);
     });
   });
@@ -195,7 +196,8 @@ describe('selectIamDataVersion', () => {
 
       const installFailure: CommandRunner = () => result('', 9);
       expect(() => selectIamDataVersion(directory, '0.21.3', installFailure)).toThrow(
-        `npm install --save-dev --save-exact ${IAM_DATA_PACKAGE}@0.21.3 failed: exit status 9`,
+        `npm install --save-dev --save-exact --package-lock-only ` +
+        `${IAM_DATA_PACKAGE}@0.21.3 failed: exit status 9`,
       );
     });
   });

--- a/scripts/release/iam-data.ts
+++ b/scripts/release/iam-data.ts
@@ -48,7 +48,11 @@ function readJson<T>(path: string): T {
   return JSON.parse(readFileSync(path, 'utf8')) as T;
 }
 
-function lockedIamDataVersion(repositoryRoot: string): string {
+export function installedIamDataDirectory(repositoryRoot: string): string {
+  return join(resolve(repositoryRoot), 'node_modules', IAM_DATA_PACKAGE, 'data');
+}
+
+export function lockedIamDataVersion(repositoryRoot: string): string {
   const lockfile = readJson<PackageLock>(join(repositoryRoot, 'package-lock.json'));
   const version = lockfile.packages?.[IAM_DATA_LOCK_PATH]?.version;
   if (version === undefined) {
@@ -67,7 +71,10 @@ function runNpm(run: CommandRunner, args: readonly string[]): string {
   return result.stdout.trim();
 }
 
-function assertRecordedVersion(repositoryRoot: string, selectedVersion: string): void {
+export function assertRecordedIamDataVersion(
+  repositoryRoot: string,
+  selectedVersion: string,
+): void {
   const packageJson = readJson<PackageJson>(join(repositoryRoot, 'package.json'));
   const lockfile = readJson<PackageLock>(join(repositoryRoot, 'package-lock.json'));
   const manifestVersion = packageJson.devDependencies?.[IAM_DATA_PACKAGE];
@@ -105,9 +112,10 @@ export function selectIamDataVersion(
     'install',
     '--save-dev',
     '--save-exact',
+    '--package-lock-only',
     `${IAM_DATA_PACKAGE}@${selectedVersion}`,
   ]);
-  assertRecordedVersion(resolvedRepository, selectedVersion);
+  assertRecordedIamDataVersion(resolvedRepository, selectedVersion);
 
   return {
     changed: selectedVersion !== previousVersion,

--- a/scripts/release/workspace.test.ts
+++ b/scripts/release/workspace.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { LOCKED_CATALOG_MINIMUMS } from '../iam-data/catalog.js';
@@ -52,6 +52,16 @@ describe('withGeneratedBuildWorkspace', () => {
   it('replaces tracked catalog modules with data from the locked package', () => {
     withFixture((directory) => {
       const repositoryRoot = createRepository(directory);
+      const realRepository = resolve(import.meta.dirname, '../..');
+      const fixtureData = join(
+        repositoryRoot,
+        'node_modules/@cloud-copilot/iam-data/data',
+      );
+      mkdirSync(dirname(fixtureData), { recursive: true });
+      symlinkSync(
+        join(realRepository, 'node_modules/@cloud-copilot/iam-data/data'),
+        fixtureData,
+      );
       let workspaceRoot = '';
 
       withGeneratedBuildWorkspace(repositoryRoot, (workspace) => {

--- a/scripts/release/workspace.ts
+++ b/scripts/release/workspace.ts
@@ -6,8 +6,7 @@ import {
   readdirSync,
   rmSync,
 } from 'node:fs';
-import { dirname, join, posix, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, posix, resolve } from 'node:path';
 
 import {
   LOCKED_CATALOG_MINIMUMS,
@@ -17,13 +16,12 @@ import {
   generateIamData,
   type IamDataGenerationResult,
 } from '../iam-data/generator.js';
+import { installedIamDataDirectory } from './iam-data.js';
 
 const GENERATED_CATALOG_MODULES = new Set([
   'iam-actions.ts',
   'service-doc-slugs.ts',
 ]);
-const LOCKED_PACKAGE_ENTRY = fileURLToPath(import.meta.resolve('@cloud-copilot/iam-data'));
-const LOCKED_DATA_DIRECTORY = resolve(dirname(LOCKED_PACKAGE_ENTRY), '../../data');
 
 export interface GeneratedBuildWorkspace {
   readonly rootDirectory: string;
@@ -95,7 +93,7 @@ export function withGeneratedBuildWorkspace<T>(
   try {
     copySourceTree(sourceDirectory, workspaceSource);
     const catalog = generateIamData({
-      dataDirectory: options.dataDirectory ?? LOCKED_DATA_DIRECTORY,
+      dataDirectory: options.dataDirectory ?? installedIamDataDirectory(resolvedRepository),
       outputDirectory: workspaceSource,
       repositoryRoot: resolvedRepository,
       minimums: options.minimums ?? LOCKED_CATALOG_MINIMUMS,

--- a/scripts/report-iam-data.ts
+++ b/scripts/report-iam-data.ts
@@ -1,0 +1,25 @@
+import { resolve } from 'node:path';
+
+import {
+  createIamDataReport,
+  writeIamDataReport,
+} from './release/iam-data-report.js';
+
+try {
+  const report = createIamDataReport(resolve(import.meta.dirname, '..'));
+  writeIamDataReport(report, {
+    ...(process.env.GITHUB_OUTPUT === undefined
+      ? {}
+      : { githubOutputPath: process.env.GITHUB_OUTPUT }),
+    ...(process.env.GITHUB_STEP_SUMMARY === undefined
+      ? {}
+      : { githubSummaryPath: process.env.GITHUB_STEP_SUMMARY }),
+  });
+  console.log(
+    `Using @cloud-copilot/iam-data ${report.version}: ` +
+    `${report.actionCount} actions across ${report.serviceCount} services.`,
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Reinstalls dependencies from the candidate lockfile before checks and bundling.
Verifies the installed IAM package and reports its version and catalog counts in the release workflow and PR.