### PR TITLE
add version to the comment marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Select and lock IAM data as part of release preparation
 - Reinstall and report the selected IAM catalog before release builds
 - Remove tracked IAM catalog modules and the standalone IAM update workflow
+- Add a versioned machine marker to generated review comments
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,10 @@ stateful mocked Octokit client. It verifies that a pull request diff containing 
 produces the expected inline review comment on the first run and reuses that same comment unchanged
 on the second run.
 
+Generated review comments include a versioned HTML marker used for machine
+identity. The visible heading remains part of the legacy migration contract;
+change either marker only with collision, migration, and synchronization tests.
+
 ## Updating IAM Data
 
 IAM data is selected and locked only during release preparation. There is no

--- a/fixtures/compatibility/grouped-comment.txt
+++ b/fixtures/compatibility/grouped-comment.txt
@@ -13,3 +13,5 @@
 1. [`s3:GetObject`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetObject)
 
 </details>
+
+<!-- expand-aws-iam-wildcards:review-comment:v1 -->

--- a/fixtures/compatibility/minimal-truncated-comment.txt
+++ b/fixtures/compatibility/minimal-truncated-comment.txt
@@ -1,3 +1,5 @@
 **IAM Wildcard Expansion**
 
 Expanded actions were omitted from this comment to stay within GitHub limits. The full expanded list is in the [workflow run logs](https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123).
+
+<!-- expand-aws-iam-wildcards:review-comment:v1 -->

--- a/fixtures/compatibility/s3-get-tagging-comment.txt
+++ b/fixtures/compatibility/s3-get-tagging-comment.txt
@@ -7,3 +7,5 @@
 1. [`s3:GetObjectTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetObjectTagging)
 1. [`s3:GetObjectVersionTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetObjectVersionTagging)
 1. [`s3:GetStorageLensConfigurationTagging`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=GetStorageLensConfigurationTagging)
+
+<!-- expand-aws-iam-wildcards:review-comment:v1 -->

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -6,6 +6,7 @@ import {
   expandWildcards,
   processFiles,
 } from './action.js';
+import { CURRENT_COMMENT_MARKER } from './comment-identity.js';
 import type { PullRequestFile, WildcardBlock } from './types.js';
 
 describe('COMMENT_MARKER', () => {
@@ -129,13 +130,15 @@ describe('createReviewComments', () => {
       expanded,
       5,
       {
-        maxCommentBodyLength: 325,
+        maxCommentBodyLength: 600,
         truncationUrl: 'https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123',
       },
     );
 
     expect(result[0]?.body).toContain('workflow run logs');
     expect(result[0]?.body).toContain('Showing first');
+    expect(result[0]?.body).toContain(CURRENT_COMMENT_MARKER);
+    expect(result[0]?.body.length).toBeLessThanOrEqual(600);
     expect(result[0]?.body).not.toContain('unknown:Action19');
   });
 });
@@ -235,7 +238,7 @@ describe('processFiles', () => {
       [],
       5,
       {
-        maxCommentBodyLength: 325,
+        maxCommentBodyLength: 600,
         truncationUrl: 'https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123',
       },
     );
@@ -247,5 +250,7 @@ describe('processFiles', () => {
       line: 1,
     });
     expect(result.comments[0]?.body).toContain('workflow run logs');
+    expect(result.comments[0]?.body).toContain(CURRENT_COMMENT_MARKER);
+    expect(result.comments[0]?.body.length).toBeLessThanOrEqual(600);
   });
 });

--- a/src/comment-identity.test.ts
+++ b/src/comment-identity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMMENT_MARKER_VERSION,
+  CURRENT_COMMENT_MARKER,
+  getCommentMarkerVersion,
+  hasCurrentCommentMarker,
+  withCurrentCommentMarker,
+} from './comment-identity.js';
+
+describe('comment marker identity', () => {
+  it('keeps the current marker and version stable', () => {
+    expect(COMMENT_MARKER_VERSION).toBe(1);
+    expect(CURRENT_COMMENT_MARKER).toBe(
+      '<!-- expand-aws-iam-wildcards:review-comment:v1 -->',
+    );
+  });
+
+  it('recognizes one marker on its own line', () => {
+    expect(getCommentMarkerVersion(`visible body\n\n${CURRENT_COMMENT_MARKER}`)).toBe(1);
+    expect(getCommentMarkerVersion(
+      `visible body\r\n  ${CURRENT_COMMENT_MARKER}  \r\n`,
+    )).toBe(1);
+    expect(hasCurrentCommentMarker(CURRENT_COMMENT_MARKER)).toBe(true);
+  });
+
+  it('recognizes future versions without treating them as current', () => {
+    const futureMarker = '<!-- expand-aws-iam-wildcards:review-comment:v2 -->';
+
+    expect(getCommentMarkerVersion(futureMarker)).toBe(2);
+    expect(hasCurrentCommentMarker(futureMarker)).toBe(false);
+  });
+
+  it.each([
+    '**IAM Wildcard Expansion**',
+    `text ${CURRENT_COMMENT_MARKER}`,
+    `prefix${CURRENT_COMMENT_MARKER}`,
+    '<!-- another-action:review-comment:v1 -->',
+    '<!-- expand-aws-iam-wildcards:review-comment:v0 -->',
+    '<!-- expand-aws-iam-wildcards:review-comment:v01 -->',
+    '<!-- expand-aws-iam-wildcards:review-comment:v999999999999999999999 -->',
+  ])('rejects a marker collision or malformed marker in %j', (body) => {
+    expect(getCommentMarkerVersion(body)).toBeNull();
+    expect(hasCurrentCommentMarker(body)).toBe(false);
+  });
+
+  it('rejects ambiguous bodies with multiple markers', () => {
+    expect(getCommentMarkerVersion(
+      `${CURRENT_COMMENT_MARKER}\n${CURRENT_COMMENT_MARKER}`,
+    )).toBeNull();
+  });
+
+  it('appends the marker once without changing visible content', () => {
+    const body = '**IAM Wildcard Expansion**\n\nVisible content.';
+    const markedBody = withCurrentCommentMarker(body);
+
+    expect(markedBody).toBe(`${body}\n\n${CURRENT_COMMENT_MARKER}`);
+    expect(withCurrentCommentMarker(markedBody)).toBe(markedBody);
+  });
+});

--- a/src/comment-identity.ts
+++ b/src/comment-identity.ts
@@ -1,0 +1,27 @@
+export const COMMENT_MARKER_VERSION = 1;
+export const CURRENT_COMMENT_MARKER =
+  '<!-- expand-aws-iam-wildcards:review-comment:v1 -->';
+
+const COMMENT_MARKER_PATTERN =
+  /^<!-- expand-aws-iam-wildcards:review-comment:v([1-9][0-9]*) -->$/;
+
+export function getCommentMarkerVersion(body: string): number | null {
+  const versions = body
+    .split(/\r?\n/)
+    .map((line) => COMMENT_MARKER_PATTERN.exec(line.trim())?.[1])
+    .filter((version): version is string => version !== undefined)
+    .map(Number)
+    .filter(Number.isSafeInteger);
+
+  return versions.length === 1 ? versions[0] ?? null : null;
+}
+
+export function hasCurrentCommentMarker(body: string): boolean {
+  return getCommentMarkerVersion(body) === COMMENT_MARKER_VERSION;
+}
+
+export function withCurrentCommentMarker(body: string): string {
+  return hasCurrentCommentMarker(body)
+    ? body
+    : `${body}\n\n${CURRENT_COMMENT_MARKER}`;
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,6 +6,7 @@ import {
   formatCommentResult,
   groupIntoConsecutiveBlocks,
 } from './utils.js';
+import { CURRENT_COMMENT_MARKER } from './comment-identity.js';
 import type { WildcardMatch } from './types.js';
 
 describe('findPotentialWildcardActions', () => {
@@ -100,6 +101,7 @@ describe('formatComment', () => {
     const result = formatComment(['s3:Get*'], ['s3:GetObject', 's3:GetBucket']);
 
     expect(result).toContain('**IAM Wildcard Expansion**');
+    expect(result).toContain(CURRENT_COMMENT_MARKER);
     expect(result).toContain('`s3:Get*` expands to 2 action(s):');
     expect(result).toContain('s3:GetObject');
     expect(result).toContain('s3:GetBucket');
@@ -144,7 +146,7 @@ describe('formatComment', () => {
       ['s3:*'],
       expanded,
       {
-        maxCommentBodyLength: 325,
+        maxCommentBodyLength: 600,
         truncationUrl: 'https://github.com/thekbb/expand-aws-iam-wildcards/actions/runs/123',
       },
     );
@@ -154,6 +156,8 @@ describe('formatComment', () => {
     expect(result.renderedActionsCount).toBeLessThan(expanded.length);
     expect(result.body).toContain('workflow run logs');
     expect(result.body).toContain('Showing first');
+    expect(result.body).toContain(CURRENT_COMMENT_MARKER);
+    expect(result.body.length).toBeLessThanOrEqual(600);
   });
 
   it('truncates oversized comments without a log link when no URL is available', () => {
@@ -161,7 +165,7 @@ describe('formatComment', () => {
     const result = formatCommentResult(
       ['s3:*'],
       expanded,
-      { maxCommentBodyLength: 325 },
+      { maxCommentBodyLength: 600 },
     );
 
     expect(result.truncated).toBe(true);
@@ -169,6 +173,8 @@ describe('formatComment', () => {
     expect(result.renderedActionsCount).toBeLessThan(expanded.length);
     expect(result.body).toContain('Showing first');
     expect(result.body).not.toContain('workflow run logs');
+    expect(result.body).toContain(CURRENT_COMMENT_MARKER);
+    expect(result.body.length).toBeLessThanOrEqual(600);
   });
 
   it('falls back to a minimal comment when nothing else fits', () => {
@@ -192,10 +198,12 @@ describe('formatComment', () => {
     expect(withLogLink.renderedActionsCount).toBe(0);
     expect(withLogLink.body).toContain('Expanded actions were omitted from this comment');
     expect(withLogLink.body).toContain('workflow run logs');
+    expect(withLogLink.body).toContain(CURRENT_COMMENT_MARKER);
 
     expect(withoutLogLink.truncated).toBe(true);
     expect(withoutLogLink.renderedActionsCount).toBe(0);
     expect(withoutLogLink.body).toContain('Expanded actions were omitted from this comment');
     expect(withoutLogLink.body).not.toContain('workflow run logs');
+    expect(withoutLogLink.body).toContain(CURRENT_COMMENT_MARKER);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import type { WildcardMatch, WildcardBlock } from './types.js';
+import { withCurrentCommentMarker } from './comment-identity.js';
 import { formatActionWithLink } from './docs.js';
 
 const IAM_WILDCARD_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]*\*[a-zA-Z0-9*?]*)["']?/g;
@@ -110,11 +111,11 @@ ${actionsList}
 </details>`
     : actionsList;
 
-  return `**IAM Wildcard Expansion**
+  return withCurrentCommentMarker(`**IAM Wildcard Expansion**
 
 ${header}${patterns}${truncationNotice}
 
-${actionsBlock}`;
+${actionsBlock}`);
 }
 
 function createMinimalCommentBody(truncationUrl?: string): string {
@@ -122,9 +123,9 @@ function createMinimalCommentBody(truncationUrl?: string): string {
     ? ` The full expanded list is in the [workflow run logs](${truncationUrl}).`
     : '';
 
-  return `**IAM Wildcard Expansion**
+  return withCurrentCommentMarker(`**IAM Wildcard Expansion**
 
-Expanded actions were omitted from this comment to stay within GitHub limits.${logMessage}`;
+Expanded actions were omitted from this comment to stay within GitHub limits.${logMessage}`);
 }
 
 export function formatCommentResult(


### PR DESCRIPTION
Adds a hidden versioned marker to generated review comments.
Covers stable rendering, malformed and ambiguous markers, future versions, and comment length limits without changing existing comment discovery.