### PR TITLE
Level up comment ownership detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reinstall and report the selected IAM catalog before release builds
 - Remove tracked IAM catalog modules and the standalone IAM update workflow
 - Add a versioned machine marker to generated review comments
+- Restrict review comment updates and deletion to safely owned current or legacy comments
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,15 @@ Generated review comments include a versioned HTML marker used for machine
 identity. The visible heading remains part of the legacy migration contract;
 change either marker only with collision, migration, and synchronization tests.
 
+Existing-comment discovery requires both a recognized comment shape and the
+author identity resolved from the configured token. PAT identity is resolved
+through GitHub's authenticated-user endpoint; GitHub Actions and GitHub App
+installation tokens fall back to GraphQL's viewer identity. User-authored
+collisions, comments from other bots, malformed markers, ambiguous markers,
+and unsupported marker versions remain unmanaged. Legacy comments are accepted
+only when their visible body matches a generated shape, then updated with the
+current machine marker when their diff anchor is reused.
+
 ## Updating IAM Data
 
 IAM data is selected and locked only during release preparation. There is no

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Consecutive wildcards are grouped into a single comment. Expanded actions link t
 Very large expansions are truncated in the PR comment to stay within GitHub comment limits,
 and the full list is written to the workflow run logs.
 
+The action only updates or removes comments that have its machine marker and an
+author matching the configured token. It also recognizes safely shaped comments
+from earlier releases so they can be migrated in place without duplicating
+threads.
+
 ## Inputs
 
 | Name | Description | Default |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,15 @@ instead of opening a public issue.
 
 We'll respond within 48 hours and work with you to understand and address the issue.
 
+## Review Comment Ownership
+
+Comment updates and deletion require both a recognized action comment shape
+and an author matching the identity resolved from the configured token. This
+supports GitHub Actions, GitHub App installation tokens, and personal access
+tokens without trusting comments from other users or bots. Safely owned
+comments from older releases are recognized by their generated body shape and
+migrated to the current machine marker in place.
+
 ## Release Verification
 
 Release tags are signed with a GPG key. The armored public key is published at

--- a/src/action.ts
+++ b/src/action.ts
@@ -9,6 +9,8 @@ import { expandIamAction } from './expand.js';
 import { matchesPatterns } from './patterns.js';
 import { LEGACY_COMMENT_HEADING } from './comment-identity.js';
 
+// TODO(v2): Remove this visible-marker compatibility export and use the comment
+// heading only from the formatter after the v1 migration window closes.
 export const COMMENT_MARKER = LEGACY_COMMENT_HEADING;
 
 export interface ReviewCommentOptions {

--- a/src/action.ts
+++ b/src/action.ts
@@ -7,8 +7,9 @@ import { extractFromDiff } from './diff.js';
 import { groupIntoConsecutiveBlocks, formatCommentResult, type FormatOptions } from './utils.js';
 import { expandIamAction } from './expand.js';
 import { matchesPatterns } from './patterns.js';
+import { LEGACY_COMMENT_HEADING } from './comment-identity.js';
 
-export const COMMENT_MARKER = '**IAM Wildcard Expansion**';
+export const COMMENT_MARKER = LEGACY_COMMENT_HEADING;
 
 export interface ReviewCommentOptions {
   readonly truncationUrl?: string;

--- a/src/comment-identity.test.ts
+++ b/src/comment-identity.test.ts
@@ -5,6 +5,7 @@ import {
   CURRENT_COMMENT_MARKER,
   getCommentMarkerVersion,
   hasCurrentCommentMarker,
+  hasLegacyCommentShape,
   withCurrentCommentMarker,
 } from './comment-identity.js';
 
@@ -48,6 +49,25 @@ describe('comment marker identity', () => {
     expect(getCommentMarkerVersion(
       `${CURRENT_COMMENT_MARKER}\n${CURRENT_COMMENT_MARKER}`,
     )).toBeNull();
+  });
+
+  it.each([
+    '**IAM Wildcard Expansion**\n\n`s3:Get*` expands to 5 action(s):\n\n1. `s3:GetObject`',
+    '**IAM Wildcard Expansion**\r\n\r\n2 wildcard patterns expand to 8 action(s):\r\n\r\nresults',
+    '**IAM Wildcard Expansion**\n\nExpanded actions were omitted from this comment to stay within GitHub limits.',
+    '**IAM Wildcard Expansion**\n\nExpanded actions were omitted from this comment to stay within GitHub limits. The full expanded list is in the [workflow run logs](https://github.com/example/actions/runs/1).',
+  ])('recognizes a generated legacy comment shape in %j', (body) => {
+    expect(hasLegacyCommentShape(body)).toBe(true);
+  });
+
+  it.each([
+    '**IAM Wildcard Expansion**',
+    '**IAM Wildcard Expansion**\n\nA human wrote this heading.',
+    `**IAM Wildcard Expansion**\n\n\`s3:Get*\` expands to 5 action(s):\n\n${CURRENT_COMMENT_MARKER}`,
+    '**IAM Wildcard Expansion**\n\n`broken` expands to 0 action(s):',
+    '**IAM Wildcard Expansion**\n\nExpanded actions were omitted from this comment to stay within GitHub limits. Extra text.',
+  ])('rejects a marker-bearing or non-generated legacy shape in %j', (body) => {
+    expect(hasLegacyCommentShape(body)).toBe(false);
   });
 
   it('appends the marker once without changing visible content', () => {

--- a/src/comment-identity.ts
+++ b/src/comment-identity.ts
@@ -1,19 +1,49 @@
 export const COMMENT_MARKER_VERSION = 1;
 export const CURRENT_COMMENT_MARKER =
   '<!-- expand-aws-iam-wildcards:review-comment:v1 -->';
+export const LEGACY_COMMENT_HEADING = '**IAM Wildcard Expansion**';
 
+const COMMENT_MARKER_NAMESPACE = 'expand-aws-iam-wildcards:review-comment:';
 const COMMENT_MARKER_PATTERN =
   /^<!-- expand-aws-iam-wildcards:review-comment:v([1-9][0-9]*) -->$/;
 
-export function getCommentMarkerVersion(body: string): number | null {
-  const versions = body
-    .split(/\r?\n/)
-    .map((line) => COMMENT_MARKER_PATTERN.exec(line.trim())?.[1])
-    .filter((version): version is string => version !== undefined)
-    .map(Number)
-    .filter(Number.isSafeInteger);
+type CommentMarkerState =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'invalid' }
+  | { readonly kind: 'valid'; readonly version: number };
 
-  return versions.length === 1 ? versions[0] ?? null : null;
+function getCommentMarkerState(body: string): CommentMarkerState {
+  const markerLines = body
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.includes(COMMENT_MARKER_NAMESPACE));
+
+  if (markerLines.length === 0) return { kind: 'none' };
+  if (markerLines.length !== 1) return { kind: 'invalid' };
+
+  const match = COMMENT_MARKER_PATTERN.exec(markerLines.join(''));
+  const version = Number(match?.[1]);
+  return match && Number.isSafeInteger(version)
+    ? { kind: 'valid', version }
+    : { kind: 'invalid' };
+}
+
+export function getCommentMarkerVersion(body: string): number | null {
+  const marker = getCommentMarkerState(body);
+  return marker.kind === 'valid' ? marker.version : null;
+}
+
+export function hasLegacyCommentShape(body: string): boolean {
+  if (getCommentMarkerState(body).kind !== 'none') return false;
+
+  const normalizedBody = body.replaceAll('\r\n', '\n');
+  const content = normalizedBody.slice(`${LEGACY_COMMENT_HEADING}\n\n`.length);
+  if (!normalizedBody.startsWith(`${LEGACY_COMMENT_HEADING}\n\n`)) return false;
+
+  return /^`[^`\n]+` expands to [1-9][0-9]* action\(s\):(?:\n|$)/.test(content)
+    || /^[1-9][0-9]* wildcard patterns expand to [1-9][0-9]* action\(s\):(?:\n|$)/.test(content)
+    || content === 'Expanded actions were omitted from this comment to stay within GitHub limits.'
+    || /^Expanded actions were omitted from this comment to stay within GitHub limits\. The full expanded list is in the \[workflow run logs\]\([^)\n]+\)\.$/.test(content);
 }
 
 export function hasCurrentCommentMarker(body: string): boolean {

--- a/src/comment-identity.ts
+++ b/src/comment-identity.ts
@@ -1,6 +1,7 @@
 export const COMMENT_MARKER_VERSION = 1;
 export const CURRENT_COMMENT_MARKER =
   '<!-- expand-aws-iam-wildcards:review-comment:v1 -->';
+// TODO(v2): Rename this to COMMENT_HEADING when legacy body matching is removed.
 export const LEGACY_COMMENT_HEADING = '**IAM Wildcard Expansion**';
 
 const COMMENT_MARKER_NAMESPACE = 'expand-aws-iam-wildcards:review-comment:';
@@ -33,6 +34,8 @@ export function getCommentMarkerVersion(body: string): number | null {
   return marker.kind === 'valid' ? marker.version : null;
 }
 
+// TODO(v2): Remove this helper, its migration fixtures, and the related legacy
+// documentation after supported v1 comments have had time to gain a marker.
 export function hasLegacyCommentShape(body: string): boolean {
   if (getCommentMarkerState(body).kind !== 'none') return false;
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -5,6 +5,7 @@ import {
   listActionReviewComments,
   syncReviewComments,
 } from './github.js';
+import { CURRENT_COMMENT_MARKER } from './comment-identity.js';
 import type { PullRequestFile, PullRequestReviewComment, ReviewComment } from './types.js';
 
 describe('listPullRequestFiles', () => {
@@ -37,19 +38,91 @@ describe('listPullRequestFiles', () => {
 });
 
 describe('listActionReviewComments', () => {
-  it('returns only comments that include the action marker', async () => {
+  const currentBody = `**IAM Wildcard Expansion**\n\n\`s3:Get*\` expands to 5 action(s):\n\nresults\n\n${CURRENT_COMMENT_MARKER}`;
+  const legacyBody = '**IAM Wildcard Expansion**\n\n`s3:Get*` expands to 5 action(s):\n\nresults';
+
+  it('does not resolve token identity when no comment has a recognized shape', async () => {
+    const getAuthenticated = vi.fn();
+    const graphql = vi.fn();
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue([{
+        id: 1,
+        body: '**IAM Wildcard Expansion**\n\nA human-readable heading is not ownership.',
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      }]),
+      graphql,
+      rest: {
+        pulls: { listReviewComments: {} },
+        users: { getAuthenticated },
+      },
+    };
+
+    await expect(listActionReviewComments(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    )).resolves.toEqual([]);
+    expect(getAuthenticated).not.toHaveBeenCalled();
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it('returns only safely shaped comments from the configured GitHub Actions identity', async () => {
     const reviewComments: PullRequestReviewComment[] = [
-      { id: 1, body: '**IAM Wildcard Expansion**\n\ncomment body', path: 'policy.tf', line: 10 },
-      { id: 2, body: 'other bot comment', path: 'policy.tf', line: 20 },
-      { id: 3, body: '**IAM Wildcard Expansion**\n\nanother comment body', path: 'policy.tf', line: 30 },
+      {
+        id: 1,
+        body: currentBody,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+      {
+        id: 2,
+        body: legacyBody,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+      {
+        id: 3,
+        body: currentBody,
+        user: { login: 'reviewer', type: 'User' },
+      },
+      {
+        id: 4,
+        body: currentBody,
+        user: { login: 'unrelated[bot]', type: 'Bot' },
+      },
+      {
+        id: 5,
+        body: currentBody,
+        user: { login: 'iam-reviewer[bot]', type: 'Bot' },
+      },
+      {
+        id: 6,
+        body: '**IAM Wildcard Expansion**\n\nA human-readable heading is not ownership.',
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+      {
+        id: 7,
+        body: `${legacyBody}\n\n<!-- expand-aws-iam-wildcards:review-comment:v2 -->`,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+      {
+        id: 8,
+        body: currentBody,
+        user: { login: null, type: 'Bot' },
+      },
     ];
     const listReviewComments = {};
     const paginate = vi.fn().mockResolvedValue(reviewComments);
+    const getAuthenticated = vi.fn().mockRejectedValue(new Error('not a user token'));
+    const graphql = vi.fn().mockResolvedValue({ viewer: { login: 'github-actions' } });
     const octokit = {
       paginate,
+      graphql,
       rest: {
         pulls: {
           listReviewComments,
+        },
+        users: {
+          getAuthenticated,
         },
       },
     };
@@ -59,10 +132,13 @@ describe('listActionReviewComments', () => {
       'thekbb',
       'expand-aws-iam-wildcards',
       42,
-      '**IAM Wildcard Expansion**',
     );
 
-    expect(result).toEqual([reviewComments[0], reviewComments[2]]);
+    expect(result).toEqual([reviewComments[0], reviewComments[1]]);
+    expect(getAuthenticated).toHaveBeenCalledOnce();
+    expect(graphql).toHaveBeenCalledWith(
+      'query ExpandAwsIamWildcardsViewer { viewer { login } }',
+    );
     expect(paginate).toHaveBeenCalledWith(listReviewComments, {
       owner: 'thekbb',
       repo: 'expand-aws-iam-wildcards',
@@ -73,14 +149,27 @@ describe('listActionReviewComments', () => {
 
   it('marks action comments that have replies', async () => {
     const reviewComments: PullRequestReviewComment[] = [
-      { id: 1, body: '**IAM Wildcard Expansion**\n\ncomment body', path: 'policy.tf', line: 10 },
+      {
+        id: 1,
+        body: currentBody,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+        path: 'policy.tf',
+        line: 10,
+      },
       { id: 2, body: 'human reply', in_reply_to_id: 1, path: 'policy.tf', line: 10 },
-      { id: 3, body: '**IAM Wildcard Expansion**\n\nanother comment body', path: 'policy.tf', line: 30 },
+      {
+        id: 3,
+        body: legacyBody,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+        path: 'policy.tf',
+        line: 30,
+      },
     ];
     const listReviewComments = {};
     const paginate = vi.fn().mockResolvedValue(reviewComments);
     const octokit = {
       paginate,
+      graphql: vi.fn().mockResolvedValue({ viewer: { login: 'github-actions[bot]' } }),
       rest: {
         pulls: {
           listReviewComments,
@@ -93,13 +182,148 @@ describe('listActionReviewComments', () => {
       'thekbb',
       'expand-aws-iam-wildcards',
       42,
-      '**IAM Wildcard Expansion**',
     );
 
     expect(result).toEqual([
       { ...reviewComments[0], hasReplies: true },
       reviewComments[2],
     ]);
+  });
+
+  it('accepts comments from the configured GitHub App bot', async () => {
+    const reviewComments: PullRequestReviewComment[] = [
+      { id: 1, body: currentBody, user: { login: 'iam-reviewer[bot]', type: 'Bot' } },
+      { id: 2, body: currentBody, user: { login: 'other-app[bot]', type: 'Bot' } },
+    ];
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue(reviewComments),
+      graphql: vi.fn().mockResolvedValue({ viewer: { login: 'iam-reviewer' } }),
+      rest: {
+        pulls: { listReviewComments: {} },
+        users: { getAuthenticated: vi.fn().mockRejectedValue(new Error('not a user token')) },
+      },
+    };
+
+    const result = await listActionReviewComments(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    );
+
+    expect(result).toEqual([reviewComments[0]]);
+  });
+
+  it('accepts only comments authored by the authenticated PAT user', async () => {
+    const reviewComments: PullRequestReviewComment[] = [
+      { id: 1, body: currentBody, user: { login: 'TheKBB', type: 'User' } },
+      { id: 2, body: legacyBody, user: { login: 'thekbb', type: 'User' } },
+      { id: 3, body: currentBody, user: { login: 'someone-else', type: 'User' } },
+    ];
+    const getAuthenticated = vi.fn().mockResolvedValue({ data: { login: 'thekbb' } });
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue(reviewComments),
+      graphql: vi.fn().mockRejectedValue(new Error('not available')),
+      rest: {
+        pulls: { listReviewComments: {} },
+        users: { getAuthenticated },
+      },
+    };
+
+    const result = await listActionReviewComments(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    );
+
+    expect(result).toEqual([reviewComments[0], reviewComments[1]]);
+    expect(getAuthenticated).toHaveBeenCalledOnce();
+  });
+
+  it('leaves user-authored comments unmanaged when PAT identity cannot be resolved', async () => {
+    const reviewComments: PullRequestReviewComment[] = [
+      { id: 1, body: currentBody, user: { login: 'thekbb', type: 'User' } },
+    ];
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue(reviewComments),
+      rest: {
+        pulls: { listReviewComments: {} },
+        users: { getAuthenticated: vi.fn().mockRejectedValue(new Error('not available')) },
+      },
+    };
+
+    await expect(listActionReviewComments(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    )).resolves.toEqual([]);
+  });
+
+  it('removes only owned duplicates and leaves an unrelated matching comment untouched', async () => {
+    const reviewComments: PullRequestReviewComment[] = [
+      {
+        id: 1,
+        body: currentBody,
+        path: 'policy.tf',
+        line: 10,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+      {
+        id: 2,
+        body: currentBody,
+        path: 'policy.tf',
+        line: 10,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+      {
+        id: 3,
+        body: currentBody,
+        path: 'policy.tf',
+        line: 10,
+        user: { login: 'reviewer', type: 'User' },
+      },
+    ];
+    const deleteReviewComment = vi.fn().mockResolvedValue({});
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue(reviewComments),
+      graphql: vi.fn().mockResolvedValue({ viewer: { login: 'github-actions' } }),
+      rest: {
+        pulls: {
+          listReviewComments: {},
+          createReview: vi.fn().mockResolvedValue({}),
+          updateReviewComment: vi.fn().mockResolvedValue({}),
+          deleteReviewComment,
+        },
+      },
+    };
+    const existingComments = await listActionReviewComments(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    );
+
+    const result = await syncReviewComments(octokit, {
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      pullNumber: 42,
+      commitSha: 'abc123',
+      comments: [{ path: 'policy.tf', line: 10, body: currentBody }],
+      existingComments,
+    });
+
+    expect(result.unchangedCount).toBe(1);
+    expect(result.deletedCount).toBe(1);
+    expect(deleteReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 2,
+    });
+    expect(deleteReviewComment).not.toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 3 }),
+    );
   });
 });
 
@@ -179,6 +403,28 @@ describe('syncReviewComments', () => {
       repo: 'expand-aws-iam-wildcards',
       comment_id: 1001,
       body: '**IAM Wildcard Expansion**\n\nnew body',
+    });
+    expect(octokit.rest.pulls.createReview).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.deleteReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('migrates an owned legacy comment to the machine marker in place', async () => {
+    const existingBody = '**IAM Wildcard Expansion**\n\n`s3:Get*` expands to 5 action(s):\n\nold results';
+    const body = `${existingBody}\n\n${CURRENT_COMMENT_MARKER}`;
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [{ path: 'policy.tf', line: 10, body }],
+      existingComments: [{ id: 1001, path: 'policy.tf', line: 10, body: existingBody }],
+    });
+
+    expect(result.updatedCount).toBe(1);
+    expect(octokit.rest.pulls.updateReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+      body,
     });
     expect(octokit.rest.pulls.createReview).not.toHaveBeenCalled();
     expect(octokit.rest.pulls.deleteReviewComment).not.toHaveBeenCalled();

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,5 @@
 import type { PullRequestFile, PullRequestReviewComment, ReviewComment } from './types.js';
+import { hasCurrentCommentMarker, hasLegacyCommentShape } from './comment-identity.js';
 
 interface PaginatedPullsClient<TItem> {
   readonly paginate: (
@@ -15,7 +16,15 @@ interface PaginatedPullsClient<TItem> {
       readonly listFiles?: unknown;
       readonly listReviewComments?: unknown;
     };
+    readonly users?: {
+      readonly getAuthenticated?: () => Promise<{
+        readonly data: { readonly login: string };
+      }>;
+    };
   };
+  readonly graphql?: (query: string) => Promise<{
+    readonly viewer: { readonly login: string };
+  }>;
 }
 
 interface ReviewSyncClient {
@@ -103,7 +112,6 @@ export async function listActionReviewComments(
   owner: string,
   repo: string,
   pullNumber: number,
-  marker: string,
 ): Promise<PullRequestReviewComment[]> {
   const reviewComments = await octokit.paginate(octokit.rest.pulls.listReviewComments, {
     owner,
@@ -118,8 +126,47 @@ export async function listActionReviewComments(
       .filter((commentId): commentId is number => commentId !== null && commentId !== undefined),
   );
 
-  return reviewComments
-    .filter((comment) => comment.body.includes(marker))
+  const candidates = reviewComments.filter((comment) =>
+    hasCurrentCommentMarker(comment.body) || hasLegacyCommentShape(comment.body),
+  );
+  let authenticatedLogin: string | undefined;
+
+  if (candidates.length > 0) {
+    try {
+      const response = await octokit.rest.users?.getAuthenticated?.();
+      authenticatedLogin = response?.data.login;
+    } catch {
+      // Installation tokens do not authenticate as users. GraphQL's viewer
+      // resolves the bot identity used for their comments.
+    }
+
+    if (authenticatedLogin === undefined) {
+      try {
+        const response = await octokit.graphql?.(
+          'query ExpandAwsIamWildcardsViewer { viewer { login } }',
+        );
+        authenticatedLogin = response?.viewer.login;
+      } catch {
+        // An unresolved token identity leaves all candidates unmanaged.
+      }
+    }
+  }
+
+  return candidates
+    .filter((comment) => {
+      const login = comment.user?.login;
+      if (!login || authenticatedLogin === undefined) return false;
+
+      const normalizedLogin = login.toLowerCase();
+      const normalizedAuthenticatedLogin = authenticatedLogin.toLowerCase();
+      if (comment.user?.type === 'Bot') {
+        return normalizedLogin.replace(/\[bot\]$/, '')
+          === normalizedAuthenticatedLogin.replace(/\[bot\]$/, '');
+      }
+
+      return comment.user?.type === 'User'
+        && normalizedLogin === normalizedAuthenticatedLogin;
+    })
     .map((comment) =>
       parentCommentIdsWithReplies.has(comment.id)
         ? { ...comment, hasReplies: true }

--- a/src/github.ts
+++ b/src/github.ts
@@ -126,6 +126,8 @@ export async function listActionReviewComments(
       .filter((commentId): commentId is number => commentId !== null && commentId !== undefined),
   );
 
+  // TODO(v2): Require the current machine marker and remove the legacy shape
+  // fallback after supported v1 comments have had time to migrate in place.
   const candidates = reviewComments.filter((comment) =>
     hasCurrentCommentMarker(comment.body) || hasLegacyCommentShape(comment.body),
   );

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -85,6 +85,7 @@ describe('runAction integration', () => {
         line: comment.line,
         position: comment.line,
         body: comment.body,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
       });
     }
 
@@ -152,6 +153,7 @@ describe('runAction integration', () => {
 
     githubMocks.getOctokit.mockReturnValue({
       paginate,
+      graphql: vi.fn().mockResolvedValue({ viewer: { login: 'github-actions[bot]' } }),
       rest: {
         pulls: {
           listFiles: listFilesRoute,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -19,7 +19,6 @@ const githubMocks = vi.hoisted(() => ({
 }));
 
 const actionMocks = vi.hoisted(() => ({
-  COMMENT_MARKER: '**IAM Wildcard Expansion**',
   processFiles: vi.fn(),
 }));
 
@@ -126,7 +125,6 @@ describe('runAction', () => {
       'thekbb',
       'expand-aws-iam-wildcards',
       42,
-      '**IAM Wildcard Expansion**',
     );
     expect(githubApiMocks.syncReviewComments).toHaveBeenCalledWith({ tag: 'octokit' }, {
       owner: 'thekbb',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { processFiles, COMMENT_MARKER, type TruncatedComment } from './action.js';
+import { processFiles, type TruncatedComment } from './action.js';
 import {
   listActionReviewComments,
   listPullRequestFiles,
@@ -96,7 +96,6 @@ export async function runAction(): Promise<void> {
       owner,
       repo,
       pullNumber,
-      COMMENT_MARKER,
     );
 
     const files = await listPullRequestFiles(octokit, owner, repo, pullNumber);

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,10 @@ export interface ReviewComment {
 export interface PullRequestReviewComment {
   readonly id: number;
   readonly body: string;
+  readonly user?: {
+    readonly login?: string | null;
+    readonly type?: string | null;
+  } | null;
   readonly in_reply_to_id?: number | null;
   readonly hasReplies?: boolean;
   readonly path?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import type { WildcardMatch, WildcardBlock } from './types.js';
-import { withCurrentCommentMarker } from './comment-identity.js';
+import { LEGACY_COMMENT_HEADING, withCurrentCommentMarker } from './comment-identity.js';
 import { formatActionWithLink } from './docs.js';
 
 const IAM_WILDCARD_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]*\*[a-zA-Z0-9*?]*)["']?/g;
@@ -111,7 +111,7 @@ ${actionsList}
 </details>`
     : actionsList;
 
-  return withCurrentCommentMarker(`**IAM Wildcard Expansion**
+  return withCurrentCommentMarker(`${LEGACY_COMMENT_HEADING}
 
 ${header}${patterns}${truncationNotice}
 
@@ -123,7 +123,7 @@ function createMinimalCommentBody(truncationUrl?: string): string {
     ? ` The full expanded list is in the [workflow run logs](${truncationUrl}).`
     : '';
 
-  return withCurrentCommentMarker(`**IAM Wildcard Expansion**
+  return withCurrentCommentMarker(`${LEGACY_COMMENT_HEADING}
 
 Expanded actions were omitted from this comment to stay within GitHub limits.${logMessage}`);
 }


### PR DESCRIPTION
Restricts comment updates and deletion to comments owned by the configured token. Supports GitHub Actions, GitHub Apps, PATs, and safe legacy migration while leaving unrelated comments untouched.