### PR TITLE
Model incomplete diff analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove tracked IAM catalog modules and the standalone IAM update workflow
 - Add a versioned machine marker to generated review comments
 - Restrict review comment updates and deletion to safely owned current or legacy comments
+- Report analyzed, binary, empty, missing, and failed pull-request diff states
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,12 @@ same strict TypeScript configuration.
 `npm run docs:check` keeps README input names, defaults, example inputs, and the
 runtime entry aligned with `action.yml` and `package.json`.
 
+Diff processing models every matching file as analyzed, binary, empty, missing
+patch text, or failed analysis. An absent API patch is never guessed to be
+binary because GitHub can also omit large text patches. Tests for this boundary
+must cover mixed-state counts, explicit binary data, malformed patches,
+renames, removals, empty patches, and no-wildcard logging.
+
 Each build copies the TypeScript source into an ignored workspace, replaces the
 tracked IAM modules there with data from the lock-selected
 `@cloud-copilot/iam-data` package, validates the catalog, and compiles through

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Consecutive wildcards are grouped into a single comment. Expanded actions link t
 Very large expansions are truncated in the PR comment to stay within GitHub comment limits,
 and the full list is written to the workflow run logs.
 
+Each run reports matching diff files as analyzed, binary, empty, missing patch
+text, or failed analysis. Missing or malformed patch data produces an explicit
+incomplete-analysis warning, and no-wildcard messages apply only to the files
+that were actually analyzed.
+
 The action only updates or removes comments that have its machine marker and an
 author matching the configured token. It also recognizes safely shaped comments
 from earlier releases so they can be migrated in place without duplicating

--- a/fixtures/compatibility/no-op-scenarios.json
+++ b/fixtures/compatibility/no-op-scenarios.json
@@ -6,7 +6,14 @@
     ],
     "filePatterns": ["**/*.tf"],
     "expectedStats": {
-      "filesScanned": 0,
+      "filesMatched": 0,
+      "fileAnalysis": {
+        "analyzed": 0,
+        "binary": 0,
+        "empty": 0,
+        "missingPatch": 0,
+        "failed": 0
+      },
       "wildcardsFound": 0,
       "blocksCreated": 0,
       "actionsExpanded": 0
@@ -19,7 +26,14 @@
     ],
     "filePatterns": ["**/*.tf"],
     "expectedStats": {
-      "filesScanned": 1,
+      "filesMatched": 1,
+      "fileAnalysis": {
+        "analyzed": 1,
+        "binary": 0,
+        "empty": 0,
+        "missingPatch": 0,
+        "failed": 0
+      },
       "wildcardsFound": 0,
       "blocksCreated": 0,
       "actionsExpanded": 0
@@ -32,7 +46,14 @@
     ],
     "filePatterns": ["**/*.tf"],
     "expectedStats": {
-      "filesScanned": 1,
+      "filesMatched": 1,
+      "fileAnalysis": {
+        "analyzed": 1,
+        "binary": 0,
+        "empty": 0,
+        "missingPatch": 0,
+        "failed": 0
+      },
       "wildcardsFound": 1,
       "blocksCreated": 1,
       "actionsExpanded": 0

--- a/fixtures/compatibility/s3-get-tagging.json
+++ b/fixtures/compatibility/s3-get-tagging.json
@@ -8,7 +8,14 @@
   "filePatterns": ["**/*.tf"],
   "collapseThreshold": 5,
   "expectedStats": {
-    "filesScanned": 1,
+    "filesMatched": 1,
+    "fileAnalysis": {
+      "analyzed": 1,
+      "binary": 0,
+      "empty": 0,
+      "missingPatch": 0,
+      "failed": 0
+    },
     "wildcardsFound": 1,
     "blocksCreated": 1,
     "actionsExpanded": 1

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -155,7 +155,14 @@ describe('processFiles', () => {
     const result = processFiles(files, ['**/*.tf'], 5);
 
     expect(result.comments).toEqual([]);
-    expect(result.stats.filesScanned).toBe(0);
+    expect(result.stats.filesMatched).toBe(0);
+    expect(result.stats.fileAnalysis).toEqual({
+      analyzed: 0,
+      binary: 0,
+      empty: 0,
+      missingPatch: 0,
+      failed: 0,
+    });
   });
 
   it('returns empty result for files with no wildcards', () => {
@@ -166,7 +173,8 @@ describe('processFiles', () => {
     const result = processFiles(files, [], 5);
 
     expect(result.comments).toEqual([]);
-    expect(result.stats.filesScanned).toBe(1);
+    expect(result.stats.filesMatched).toBe(1);
+    expect(result.stats.fileAnalysis.analyzed).toBe(1);
     expect(result.stats.wildcardsFound).toBe(0);
   });
 
@@ -203,10 +211,10 @@ describe('processFiles', () => {
 
     const result = processFiles(files, ['**/*.tf'], 5);
 
-    expect(result.stats.filesScanned).toBe(1);
+    expect(result.stats.filesMatched).toBe(1);
   });
 
-  it('scans all files when no patterns are provided', () => {
+  it('matches all files when no patterns are provided', () => {
     const files: PullRequestFile[] = [
       { filename: 'a.tf', patch: makePatch(['"s3:Get*"']) },
       { filename: 'b.json', patch: makePatch(['"ec2:Describe*"']) },
@@ -214,10 +222,10 @@ describe('processFiles', () => {
 
     const result = processFiles(files, [], 5);
 
-    expect(result.stats.filesScanned).toBe(2);
+    expect(result.stats.filesMatched).toBe(2);
   });
 
-  it('handles files without patches', () => {
+  it('reports matched files without patches as incomplete analysis', () => {
     const files: PullRequestFile[] = [
       { filename: 'policy.tf' },
     ];
@@ -225,7 +233,37 @@ describe('processFiles', () => {
     const result = processFiles(files, [], 5);
 
     expect(result.comments).toEqual([]);
-    expect(result.stats.filesScanned).toBe(1);
+    expect(result.stats.filesMatched).toBe(1);
+    expect(result.stats.fileAnalysis).toEqual({
+      analyzed: 0,
+      binary: 0,
+      empty: 0,
+      missingPatch: 1,
+      failed: 0,
+    });
+  });
+
+  it('retains wildcard results while counting every diff analysis state', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'analyzed.tf', patch: makePatch(['"s3:Get*"']) },
+      { filename: 'binary.tf', patch: 'Binary files a/binary.tf and b/binary.tf differ' },
+      { filename: 'empty.tf', patch: '' },
+      { filename: 'missing.tf' },
+      { filename: 'failed.tf', patch: '+ "ec2:Describe*"' },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.stats.filesMatched).toBe(5);
+    expect(result.stats.fileAnalysis).toEqual({
+      analyzed: 1,
+      binary: 1,
+      empty: 1,
+      missingPatch: 1,
+      failed: 1,
+    });
+    expect(result.stats.wildcardsFound).toBe(1);
+    expect(result.comments).toHaveLength(1);
   });
 
   it('returns truncated comment metadata when a comment body is trimmed', () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -3,7 +3,7 @@ import type {
   ReviewComment,
   WildcardBlock,
 } from './types.js';
-import { extractFromDiff } from './diff.js';
+import { extractFromDiff, type DiffAnalysisCounts } from './diff.js';
 import { groupIntoConsecutiveBlocks, formatCommentResult, type FormatOptions } from './utils.js';
 import { expandIamAction } from './expand.js';
 import { matchesPatterns } from './patterns.js';
@@ -117,7 +117,8 @@ export function createReviewComments(
 }
 
 export interface ProcessingStats {
-  readonly filesScanned: number;
+  readonly filesMatched: number;
+  readonly fileAnalysis: DiffAnalysisCounts;
   readonly wildcardsFound: number;
   readonly blocksCreated: number;
   readonly actionsExpanded: number;
@@ -142,17 +143,29 @@ export function processFiles(
   if (filteredFiles.length === 0) {
     return {
       comments: [],
-      stats: { filesScanned: 0, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+      stats: {
+        filesMatched: 0,
+        fileAnalysis: { analyzed: 0, binary: 0, empty: 0, missingPatch: 0, failed: 0 },
+        wildcardsFound: 0,
+        blocksCreated: 0,
+        actionsExpanded: 0,
+      },
       truncatedComments: [],
     };
   }
 
-  const { wildcardMatches } = extractFromDiff(filteredFiles);
+  const { wildcardMatches, counts: fileAnalysis } = extractFromDiff(filteredFiles);
 
   if (wildcardMatches.length === 0) {
     return {
       comments: [],
-      stats: { filesScanned: filteredFiles.length, wildcardsFound: 0, blocksCreated: 0, actionsExpanded: 0 },
+      stats: {
+        filesMatched: filteredFiles.length,
+        fileAnalysis,
+        wildcardsFound: 0,
+        blocksCreated: 0,
+        actionsExpanded: 0,
+      },
       truncatedComments: [],
     };
   }
@@ -165,7 +178,8 @@ export function processFiles(
     return {
       comments: [],
       stats: {
-        filesScanned: filteredFiles.length,
+        filesMatched: filteredFiles.length,
+        fileAnalysis,
         wildcardsFound: wildcardMatches.length,
         blocksCreated: blocks.length,
         actionsExpanded: 0,
@@ -184,7 +198,8 @@ export function processFiles(
   return {
     comments: reviewComments.comments,
     stats: {
-      filesScanned: filteredFiles.length,
+      filesMatched: filteredFiles.length,
+      fileAnalysis,
       wildcardsFound: wildcardMatches.length,
       blocksCreated: blocks.length,
       actionsExpanded: expandedActions.size,

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -68,6 +68,28 @@ describe('extractFromDiff', () => {
     expect(wildcardMatches).toHaveLength(0);
   });
 
+  it('analyzes renamed and removed text files without scanning removed lines', () => {
+    const result = extractFromDiff([
+      {
+        filename: 'renamed-policy.tf',
+        patch: '@@ -1 +1 @@\n-"s3:GetObject"\n+"s3:Get*"',
+      },
+      {
+        filename: 'removed-policy.tf',
+        patch: '@@ -1 +0,0 @@\n-"ec2:Describe*"',
+      },
+    ]);
+
+    expect(result.files.map((file) => [file.filename, file.state])).toEqual([
+      ['renamed-policy.tf', 'analyzed'],
+      ['removed-policy.tf', 'analyzed'],
+    ]);
+    expect(result.wildcardMatches).toEqual([
+      { action: 's3:Get*', line: 1, file: 'renamed-policy.tf' },
+    ]);
+    expect(result.counts.analyzed).toBe(2);
+  });
+
   it('handles multiple files', () => {
     const files = [
       {
@@ -91,9 +113,9 @@ describe('extractFromDiff', () => {
     expect(wildcardMatches[1]?.file).toBe('policy2.json');
   });
 
-  it('handles files without patches', () => {
+  it('reports files without patch text as missing instead of silently skipping them', () => {
     const files = [
-      { filename: 'binary.png' },
+      { filename: 'large-policy.json' },
       {
         filename: 'policy.json',
         patch: `@@ -1,2 +1,2 @@
@@ -102,10 +124,63 @@ describe('extractFromDiff', () => {
       },
     ];
 
-    const { wildcardMatches } = extractFromDiff(files);
+    const result = extractFromDiff(files);
 
-    expect(wildcardMatches).toHaveLength(1);
-    expect(wildcardMatches[0]?.file).toBe('policy.json');
+    expect(result.wildcardMatches).toHaveLength(1);
+    expect(result.wildcardMatches[0]?.file).toBe('policy.json');
+    expect(result.files).toEqual([
+      { filename: 'large-policy.json', state: 'missing-patch', wildcardMatches: [] },
+      {
+        filename: 'policy.json',
+        state: 'analyzed',
+        wildcardMatches: result.wildcardMatches,
+      },
+    ]);
+    expect(result.counts).toEqual({
+      analyzed: 1,
+      binary: 0,
+      empty: 0,
+      missingPatch: 1,
+      failed: 0,
+    });
+  });
+
+  it.each([
+    'Binary files a/image.png and b/image.png differ',
+    'GIT binary patch\nliteral 0',
+  ])('reports an explicit binary patch without analyzing %j', (patch) => {
+    const result = extractFromDiff([{ filename: 'image.png', patch }]);
+
+    expect(result.files).toEqual([
+      { filename: 'image.png', state: 'binary', wildcardMatches: [] },
+    ]);
+    expect(result.counts.binary).toBe(1);
+    expect(result.wildcardMatches).toEqual([]);
+  });
+
+  it('reports malformed nonempty patch text as failed analysis', () => {
+    const result = extractFromDiff([{
+      filename: 'policy.tf',
+      patch: '+ "s3:Get*"',
+    }]);
+
+    expect(result.files).toEqual([
+      { filename: 'policy.tf', state: 'failed', wildcardMatches: [] },
+    ]);
+    expect(result.counts.failed).toBe(1);
+    expect(result.wildcardMatches).toEqual([]);
+  });
+
+  it('discards partial matches when a later hunk header is malformed', () => {
+    const result = extractFromDiff([{
+      filename: 'policy.tf',
+      patch: '@@ -1 +1 @@\n+"s3:Get*"\n@@ malformed @@\n+"ec2:Describe*"',
+    }]);
+
+    expect(result.files).toEqual([
+      { filename: 'policy.tf', state: 'failed', wildcardMatches: [] },
+    ]);
+    expect(result.wildcardMatches).toEqual([]);
   });
 
   it('tracks line numbers across multiple hunks', () => {
@@ -187,7 +262,7 @@ describe('extractFromDiff', () => {
     expect(wildcardMatches[1]?.file).toBe('policy.tf');
   });
 
-  it('skips files with empty string patches', () => {
+  it('reports empty string patches while retaining other file results', () => {
     const files = [
       { filename: 'policy.tf', patch: '' },
       {
@@ -198,10 +273,16 @@ describe('extractFromDiff', () => {
       },
     ];
 
-    const { wildcardMatches } = extractFromDiff(files);
+    const result = extractFromDiff(files);
 
-    expect(wildcardMatches).toHaveLength(1);
-    expect(wildcardMatches[0]?.action).toBe('s3:Get*');
+    expect(result.wildcardMatches).toHaveLength(1);
+    expect(result.wildcardMatches[0]?.action).toBe('s3:Get*');
+    expect(result.files[0]).toEqual({
+      filename: 'policy.tf',
+      state: 'empty',
+      wildcardMatches: [],
+    });
+    expect(result.counts.empty).toBe(1);
   });
 
   it('does not count the no-newline marker as a destination line', () => {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,30 +1,70 @@
 import type { PullRequestFile, WildcardMatch } from './types.js';
 import { findPotentialWildcardActions } from './utils.js';
 
+export type DiffAnalysisState =
+  | 'analyzed'
+  | 'binary'
+  | 'empty'
+  | 'missing-patch'
+  | 'failed';
+
+export interface FileDiffAnalysis {
+  readonly filename: string;
+  readonly state: DiffAnalysisState;
+  readonly wildcardMatches: readonly WildcardMatch[];
+}
+
+export interface DiffAnalysisCounts {
+  readonly analyzed: number;
+  readonly binary: number;
+  readonly empty: number;
+  readonly missingPatch: number;
+  readonly failed: number;
+}
+
 export interface DiffResults {
   readonly wildcardMatches: WildcardMatch[];
+  readonly files: readonly FileDiffAnalysis[];
+  readonly counts: DiffAnalysisCounts;
+}
+
+interface PatchExtractionResult {
+  readonly wildcardMatches: WildcardMatch[];
+  readonly hasHunk: boolean;
+  readonly failed: boolean;
 }
 
 function isNoNewlineMarker(line: string): boolean {
   return line === '\\ No newline at end of file';
 }
 
-function extractFromPatch(patch: string, filename: string): DiffResults {
+function isExplicitBinaryPatch(patch: string): boolean {
+  return patch.split('\n').some((line) =>
+    line === 'GIT binary patch' || /^Binary files .+ differ$/.test(line),
+  );
+}
+
+function extractFromPatch(patch: string, filename: string): PatchExtractionResult {
   const wildcardMatches: WildcardMatch[] = [];
   let currentLine = 0;
+  let hasHunk = false;
+  let failed = false;
 
   for (const line of patch.split('\n')) {
     const hunkStart = parseHunkHeader(line);
     if (hunkStart !== null) {
       currentLine = hunkStart - 1;
+      hasHunk = true;
       continue;
     }
 
-    if (isNoNewlineMarker(line)) {
+    if (line.startsWith('@@')) {
+      failed = true;
       continue;
     }
 
-    if (line.startsWith('-')) continue;
+    if (isNoNewlineMarker(line)) continue;
+    if (!hasHunk || line.startsWith('-')) continue;
 
     currentLine++;
 
@@ -35,7 +75,58 @@ function extractFromPatch(patch: string, filename: string): DiffResults {
     }
   }
 
-  return { wildcardMatches };
+  return { wildcardMatches, hasHunk, failed };
+}
+
+function analyzeFile(file: PullRequestFile): FileDiffAnalysis {
+  if (file.patch === undefined) {
+    return { filename: file.filename, state: 'missing-patch', wildcardMatches: [] };
+  }
+
+  if (file.patch.length === 0) {
+    return { filename: file.filename, state: 'empty', wildcardMatches: [] };
+  }
+
+  if (isExplicitBinaryPatch(file.patch)) {
+    return { filename: file.filename, state: 'binary', wildcardMatches: [] };
+  }
+
+  const result = extractFromPatch(file.patch, file.filename);
+  return result.hasHunk && !result.failed
+    ? { filename: file.filename, state: 'analyzed', wildcardMatches: result.wildcardMatches }
+    : { filename: file.filename, state: 'failed', wildcardMatches: [] };
+}
+
+function countAnalyses(files: readonly FileDiffAnalysis[]): DiffAnalysisCounts {
+  const counts = {
+    analyzed: 0,
+    binary: 0,
+    empty: 0,
+    missingPatch: 0,
+    failed: 0,
+  };
+
+  for (const file of files) {
+    switch (file.state) {
+      case 'analyzed':
+        counts.analyzed += 1;
+        break;
+      case 'binary':
+        counts.binary += 1;
+        break;
+      case 'empty':
+        counts.empty += 1;
+        break;
+      case 'missing-patch':
+        counts.missingPatch += 1;
+        break;
+      case 'failed':
+        counts.failed += 1;
+        break;
+    }
+  }
+
+  return counts;
 }
 
 export function parseHunkHeader(line: string): number | null {
@@ -44,17 +135,10 @@ export function parseHunkHeader(line: string): number | null {
 }
 
 export function extractFromDiff(files: readonly PullRequestFile[]): DiffResults {
-  return files
-    .filter(
-      (file): file is PullRequestFile & { patch: string } =>
-        typeof file.patch === 'string' && file.patch.length > 0,
-    )
-    .map((file) => extractFromPatch(file.patch, file.filename))
-    .reduce<DiffResults>(
-      (acc, result) => {
-        acc.wildcardMatches.push(...result.wildcardMatches);
-        return acc;
-      },
-      { wildcardMatches: [] },
-    );
+  const analyses = files.map(analyzeFile);
+  return {
+    wildcardMatches: analyses.flatMap((file) => file.wildcardMatches),
+    files: analyses,
+    counts: countAnalyses(analyses),
+  };
 }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -210,8 +210,12 @@ describe('runAction integration', () => {
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Synchronized comments: 1 created, 0 updated, 0 unchanged',
     );
-    expect(coreMocks.info).toHaveBeenCalledWith('Scanned 1 file(s)');
-    expect(coreMocks.info).toHaveBeenCalledWith('No IAM wildcard actions found in the changes.');
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'Diff analysis: 1 analyzed, 0 binary, 0 empty, 0 missing patch, 0 failed',
+    );
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'No IAM wildcard actions found in the analyzed files.',
+    );
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Deleted 1 existing comment(s) from previous runs',
     );

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -35,6 +35,10 @@ vi.mock('./github.js', () => githubApiMocks);
 
 import { runAction } from './main.js';
 
+function analyzedFiles(count: number) {
+  return { analyzed: count, binary: 0, empty: 0, missingPatch: 0, failed: 0 };
+}
+
 describe('runAction', () => {
   const originalGithubRunId = process.env.GITHUB_RUN_ID;
   const originalGithubServerUrl = process.env.GITHUB_SERVER_URL;
@@ -77,7 +81,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [],
       stats: {
-        filesScanned: 0,
+        filesMatched: 0,
+        fileAnalysis: analyzedFiles(0),
         wildcardsFound: 0,
         blocksCreated: 0,
         actionsExpanded: 0,
@@ -151,7 +156,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 1,
         blocksCreated: 1,
         actionsExpanded: 1,
@@ -202,7 +208,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 1,
         blocksCreated: 1,
         actionsExpanded: 1,
@@ -253,7 +260,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 1,
         blocksCreated: 1,
         actionsExpanded: 1,
@@ -285,7 +293,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 1,
         blocksCreated: 1,
         actionsExpanded: 1,
@@ -321,7 +330,7 @@ describe('runAction', () => {
     );
   });
 
-  it('syncs empty comments when scanned files contain no IAM wildcards', async () => {
+  it('syncs empty comments when analyzed files contain no IAM wildcards', async () => {
     githubMocks.context.payload = {
       pull_request: {
         number: 42,
@@ -333,7 +342,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [],
       stats: {
-        filesScanned: 2,
+        filesMatched: 2,
+        fileAnalysis: analyzedFiles(2),
         wildcardsFound: 0,
         blocksCreated: 0,
         actionsExpanded: 0,
@@ -351,8 +361,52 @@ describe('runAction', () => {
       comments: [],
       existingComments: [],
     });
-    expect(coreMocks.info).toHaveBeenCalledWith('Scanned 2 file(s)');
-    expect(coreMocks.info).toHaveBeenCalledWith('No IAM wildcard actions found in the changes.');
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'Diff analysis: 2 analyzed, 0 binary, 0 empty, 0 missing patch, 0 failed',
+    );
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'No IAM wildcard actions found in the analyzed files.',
+    );
+  });
+
+  it('warns when a no-wildcard result is based on incomplete diff analysis', async () => {
+    githubMocks.context.payload = {
+      pull_request: {
+        number: 42,
+        head: {
+          sha: 'abc123',
+        },
+      },
+    };
+    actionMocks.processFiles.mockReturnValue({
+      comments: [],
+      stats: {
+        filesMatched: 3,
+        fileAnalysis: {
+          analyzed: 1,
+          binary: 0,
+          empty: 0,
+          missingPatch: 1,
+          failed: 1,
+        },
+        wildcardsFound: 0,
+        blocksCreated: 0,
+        actionsExpanded: 0,
+      },
+      truncatedComments: [],
+    });
+
+    await runAction();
+
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'Diff analysis: 1 analyzed, 0 binary, 0 empty, 1 missing patch, 1 failed',
+    );
+    expect(coreMocks.warning).toHaveBeenCalledWith(
+      'Diff analysis was incomplete for 2 file(s): 1 missing patch, 1 failed',
+    );
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'No IAM wildcard actions found in the analyzed files.',
+    );
   });
 
   it('syncs empty comments when found wildcards do not expand', async () => {
@@ -367,7 +421,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 2,
         blocksCreated: 1,
         actionsExpanded: 0,
@@ -385,7 +440,9 @@ describe('runAction', () => {
       comments: [],
       existingComments: [],
     });
-    expect(coreMocks.info).toHaveBeenCalledWith('Scanned 1 file(s)');
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'Diff analysis: 1 analyzed, 0 binary, 0 empty, 0 missing patch, 0 failed',
+    );
     expect(coreMocks.info).toHaveBeenCalledWith('Found 2 wildcard(s), grouped into 1 block(s)');
     expect(coreMocks.info).toHaveBeenCalledWith('No wildcard actions could be expanded.');
   });
@@ -402,7 +459,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 2,
         blocksCreated: 1,
         actionsExpanded: 2,
@@ -420,7 +478,9 @@ describe('runAction', () => {
       comments: [],
       existingComments: [],
     });
-    expect(coreMocks.info).toHaveBeenCalledWith('Scanned 1 file(s)');
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      'Diff analysis: 1 analyzed, 0 binary, 0 empty, 0 missing patch, 0 failed',
+    );
     expect(coreMocks.info).toHaveBeenCalledWith('Found 2 wildcard(s), grouped into 1 block(s)');
     expect(coreMocks.info).toHaveBeenCalledWith('No comments to post.');
   });
@@ -437,7 +497,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 1,
         blocksCreated: 1,
         actionsExpanded: 1,
@@ -481,7 +542,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 1,
         blocksCreated: 1,
         actionsExpanded: 1,
@@ -527,7 +589,8 @@ describe('runAction', () => {
     actionMocks.processFiles.mockReturnValue({
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       stats: {
-        filesScanned: 1,
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
         wildcardsFound: 1,
         blocksCreated: 1,
         actionsExpanded: 1,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { processFiles, type TruncatedComment } from './action.js';
+import { processFiles, type ProcessingStats, type TruncatedComment } from './action.js';
 import {
   listActionReviewComments,
   listPullRequestFiles,
@@ -65,6 +65,26 @@ function logReviewCommentSyncResult(result: SyncReviewCommentsResult): void {
   }
 }
 
+function logDiffAnalysis(stats: ProcessingStats): void {
+  const { analyzed, binary, empty, missingPatch, failed } = stats.fileAnalysis;
+  const summary = [
+    `${analyzed} analyzed`,
+    `${binary} binary`,
+    `${empty} empty`,
+    `${missingPatch} missing patch`,
+    `${failed} failed`,
+  ].join(', ');
+  core.info(`Diff analysis: ${summary}`);
+
+  const incompleteCount = missingPatch + failed;
+  if (incompleteCount > 0) {
+    const incompleteSummary = `${missingPatch} missing patch, ${failed} failed`;
+    core.warning(
+      `Diff analysis was incomplete for ${incompleteCount} file(s): ${incompleteSummary}`,
+    );
+  }
+}
+
 export async function runAction(): Promise<void> {
   try {
     const { context } = github;
@@ -107,7 +127,7 @@ export async function runAction(): Promise<void> {
       reviewCommentOptions,
     );
 
-    if (stats.filesScanned === 0) {
+    if (stats.filesMatched === 0) {
       logReviewCommentSyncResult(await syncReviewComments(octokit, {
         owner,
         repo,
@@ -120,7 +140,7 @@ export async function runAction(): Promise<void> {
       return;
     }
 
-    core.info(`Scanned ${stats.filesScanned} file(s)`);
+    logDiffAnalysis(stats);
 
     if (stats.wildcardsFound === 0) {
       logReviewCommentSyncResult(await syncReviewComments(octokit, {
@@ -131,7 +151,7 @@ export async function runAction(): Promise<void> {
         comments: [],
         existingComments,
       }));
-      core.info('No IAM wildcard actions found in the changes.');
+      core.info('No IAM wildcard actions found in the analyzed files.');
       return;
     }
 


### PR DESCRIPTION
Models every matching diff as analyzed, binary, empty, missing, or failed without guessing why GitHub omitted a patch.
Logs counts and warns when no-wildcard results are incomplete.
Adds mixed-state, malformed-hunk, rename, removal, and no-wildcard coverage