### PR TITLE
Handle incomplete pull request diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a versioned machine marker to generated review comments
 - Restrict review comment updates and deletion to safely owned current or legacy comments
 - Report analyzed, binary, empty, missing, and failed pull-request diff states
+- Recover omitted patches from the full pull-request diff and preserve stale comments if analysis remains incomplete
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,12 @@ runtime entry aligned with `action.yml` and `package.json`.
 
 Diff processing models every matching file as analyzed, binary, empty, missing
 patch text, or failed analysis. An absent API patch is never guessed to be
-binary because GitHub can also omit large text patches. Tests for this boundary
-must cover mixed-state counts, explicit binary data, malformed patches,
-renames, removals, empty patches, and no-wildcard logging.
+binary because GitHub can also omit large text patches. Missing and failed
+patches are retried from the full pull-request diff. If retrieval fails or the
+full diff is incomplete, partial findings remain usable but stale-comment
+deletion is disabled for that run. Tests for this boundary must cover mixed
+states, explicit binary data, malformed patches, renames, removals, quoted
+paths, fallback permissions and truncation, and protected stale comments.
 
 Each build copies the TypeScript source into an ignored workspace, replaces the
 tracked IAM modules there with data from the lock-selected

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Very large expansions are truncated in the PR comment to stay within GitHub comm
 and the full list is written to the workflow run logs.
 
 Each run reports matching diff files as analyzed, binary, empty, missing patch
-text, or failed analysis. Missing or malformed patch data produces an explicit
-incomplete-analysis warning, and no-wildcard messages apply only to the files
-that were actually analyzed.
+text, or failed analysis. Missing or malformed patch data triggers a
+full-PR-diff fallback. If files remain unresolved because the fallback is
+unavailable or incomplete, the action reports an incomplete-analysis warning,
+keeps findings from analyzed files, and preserves stale comments. No-wildcard
+messages apply only to the files that were actually analyzed.
 
 The action only updates or removes comments that have its machine marker and an
 author matching the configured token. It also recognizes safely shaped comments

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,8 @@ and an author matching the identity resolved from the configured token. This
 supports GitHub Actions, GitHub App installation tokens, and personal access
 tokens without trusting comments from other users or bots. Safely owned
 comments from older releases are recognized by their generated body shape and
-migrated to the current machine marker in place.
+migrated to the current machine marker in place. Stale comments are not deleted
+when pull-request diff analysis remains incomplete after fallback retrieval.
 
 ## Release Verification
 

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractFromDiff, parseHunkHeader } from './diff.js';
+import { extractFromDiff, parseHunkHeader, recoverFilePatchesFromDiff } from './diff.js';
 
 describe('parseHunkHeader', () => {
   it('parses simple hunk header', () => {
@@ -314,5 +314,158 @@ describe('extractFromDiff', () => {
       line: 11,
       file: 'policy.json',
     });
+  });
+});
+
+describe('recoverFilePatchesFromDiff', () => {
+  it('recovers missing and failed text patches without replacing analyzed patches', () => {
+    const analyzedPatch = '@@ -1 +1 @@\n+"s3:Get*"';
+    const files = [
+      { filename: 'missing.tf' },
+      { filename: 'failed.tf', patch: '+"malformed"' },
+      { filename: 'analyzed.tf', patch: analyzedPatch },
+      { filename: 'removed.tf' },
+    ];
+    const diff = `diff --git a/missing.tf b/missing.tf
+--- a/missing.tf
++++ b/missing.tf
+@@ -1 +1 @@
+-"s3:GetObject"
++"s3:Get*"
+@@ -10 +10 @@
+-"lambda:GetFunction"
++"lambda:Get*"
+diff --git a/failed.tf b/failed.tf
+--- a/failed.tf
++++ b/failed.tf
+@@ -1 +1 @@
+-"ec2:DescribeInstances"
++"ec2:Describe*"
+diff --git a/analyzed.tf b/analyzed.tf
+--- a/analyzed.tf
++++ b/analyzed.tf
+@@ -1 +1 @@
+-"s3:GetObject"
++"s3:Put*"
+diff --git a/removed.tf b/removed.tf
+deleted file mode 100644
+--- a/removed.tf
++++ /dev/null
+@@ -1 +0,0 @@
+-"s3:Get*"
+`;
+
+    const recovered = recoverFilePatchesFromDiff(files, diff);
+    const result = extractFromDiff(recovered);
+
+    expect(result.counts).toEqual({
+      analyzed: 4,
+      binary: 0,
+      empty: 0,
+      missingPatch: 0,
+      failed: 0,
+    });
+    expect(result.wildcardMatches.map((match) => match.action)).toEqual([
+      's3:Get*',
+      'lambda:Get*',
+      'ec2:Describe*',
+      's3:Get*',
+    ]);
+    expect(recovered[2]?.patch).toBe(analyzedPatch);
+  });
+
+  it('recovers explicit binary and empty file states from sections without hunks', () => {
+    const files = [
+      { filename: 'image.png' },
+      { filename: 'empty file.tf' },
+      { filename: 'renamed.tf' },
+    ];
+    const diff = `diff --git a/image.png b/image.png
+new file mode 100644
+index 0000000..1234567
+Binary files /dev/null and b/image.png differ
+diff --git a/empty file.tf b/empty file.tf
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/old.tf b/renamed.tf
+similarity index 100%
+rename from old.tf
+rename to renamed.tf`;
+
+    const result = extractFromDiff(recoverFilePatchesFromDiff(files, diff));
+
+    expect(result.files.map((file) => [file.filename, file.state])).toEqual([
+      ['image.png', 'binary'],
+      ['empty file.tf', 'empty'],
+      ['renamed.tf', 'empty'],
+    ]);
+  });
+
+  it('recovers C-quoted Git paths with escaped and UTF-8 octal characters', () => {
+    const filename = 'policy\té.tf';
+    const encodedFilename = 'policy\\t\\303\\251.tf';
+    const diff = `diff --git "a/${encodedFilename}" "b/${encodedFilename}"
+--- "a/${encodedFilename}"
++++ "b/${encodedFilename}"
+@@ -1 +1 @@
+-"s3:GetObject"
++"s3:Get*"`;
+
+    const recovered = recoverFilePatchesFromDiff([{ filename }], diff);
+
+    expect(extractFromDiff(recovered).wildcardMatches).toEqual([
+      { action: 's3:Get*', line: 1, file: filename },
+    ]);
+  });
+
+  it.each([
+    'diff --git "a/policy.tf" "b/policy.tf',
+    'diff --git "a/policy\\q.tf" "b/policy\\q.tf"\n--- "a/policy\\q.tf"\n+++ "b/policy\\q.tf"',
+  ])('rejects a malformed quoted Git path in %j', (diff) => {
+    const result = extractFromDiff(
+      recoverFilePatchesFromDiff([{ filename: 'policy.tf' }], diff),
+    );
+
+    expect(result.counts.missingPatch).toBe(1);
+  });
+
+  it('leaves unmatched files missing when a large full diff is incomplete', () => {
+    const files = [{ filename: 'not-in-diff.tf' }];
+
+    const recovered = recoverFilePatchesFromDiff(
+      files,
+      'diff --git a/other.tf b/other.tf\n--- a/other.tf\n+++ b/other.tf\n@@ -1 +1 @@\n-old\n+new',
+    );
+
+    expect(recovered).toEqual(files);
+    expect(extractFromDiff(recovered).counts.missingPatch).toBe(1);
+  });
+
+  it('leaves a matched no-hunk section missing when the full diff is truncated', () => {
+    const files = [{ filename: 'policy.tf' }];
+    const diff = `diff --git a/policy.tf b/policy.tf
+index 1234567..7654321 100644
+--- a/policy.tf
++++ b/policy.tf`;
+
+    const recovered = recoverFilePatchesFromDiff(files, diff);
+
+    expect(recovered).toEqual(files);
+    expect(extractFromDiff(recovered).counts.missingPatch).toBe(1);
+  });
+
+  it('leaves a matched partial hunk missing when the full diff is truncated', () => {
+    const files = [{ filename: 'policy.tf' }];
+    const diff = `diff --git a/policy.tf b/policy.tf
+--- a/policy.tf
++++ b/policy.tf
+@@ -1,3 +1,3 @@
+-"s3:GetObject"
++"s3:Get*"`;
+
+    const recovered = recoverFilePatchesFromDiff(files, diff);
+
+    expect(recovered).toEqual(files);
+    expect(extractFromDiff(recovered).counts.missingPatch).toBe(1);
   });
 });

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'node:buffer';
+
 import type { PullRequestFile, WildcardMatch } from './types.js';
 import { findPotentialWildcardActions } from './utils.js';
 
@@ -95,6 +97,184 @@ function analyzeFile(file: PullRequestFile): FileDiffAnalysis {
   return result.hasHunk && !result.failed
     ? { filename: file.filename, state: 'analyzed', wildcardMatches: result.wildcardMatches }
     : { filename: file.filename, state: 'failed', wildcardMatches: [] };
+}
+
+function decodeGitPath(value: string): string | null {
+  if (!value.startsWith('"')) return value;
+  if (!value.endsWith('"')) return null;
+
+  const bytes: number[] = [];
+  const escapedCharacters: Readonly<Record<string, string>> = {
+    a: '\u0007',
+    b: '\b',
+    f: '\f',
+    n: '\n',
+    r: '\r',
+    t: '\t',
+    v: '\u000b',
+    '\\': '\\',
+    '"': '"',
+  };
+
+  for (let index = 1; index < value.length - 1; index++) {
+    const character = value.charAt(index);
+    if (character !== '\\') {
+      bytes.push(...Buffer.from(character));
+      continue;
+    }
+
+    const escape = value.charAt(++index);
+
+    if (/^[0-7]$/.test(escape)) {
+      let octal = escape;
+      while (octal.length < 3 && /^[0-7]$/.test(value.charAt(index + 1))) {
+        octal += value[++index];
+      }
+      bytes.push(parseInt(octal, 8));
+      continue;
+    }
+
+    const decoded = escapedCharacters[escape];
+    if (decoded === undefined) return null;
+    bytes.push(...Buffer.from(decoded));
+  }
+
+  return Buffer.from(bytes).toString('utf8');
+}
+
+function getDiffHeaderFilename(line: string): string | null {
+  const encodedPath = line.slice(4);
+  const path = decodeGitPath(encodedPath);
+  if (path === null || path === '/dev/null') return null;
+  return path.startsWith('a/') || path.startsWith('b/') ? path.slice(2) : null;
+}
+
+function findClosingQuote(value: string, start: number): number | null {
+  for (let index = start + 1; index < value.length; index++) {
+    if (value[index] === '\\') {
+      index++;
+    } else if (value[index] === '"') {
+      return index;
+    }
+  }
+  return null;
+}
+
+function getDiffGitFilename(line: string): string | null {
+  const paths = line.slice('diff --git '.length);
+  let currentPath: string;
+
+  if (paths.startsWith('"')) {
+    const previousPathEnd = findClosingQuote(paths, 0);
+    if (previousPathEnd === null) return null;
+    currentPath = paths.slice(previousPathEnd + 1).trimStart();
+  } else {
+    const currentPathStart = paths.lastIndexOf(' b/');
+    if (currentPathStart < 0) return null;
+    currentPath = paths.slice(currentPathStart + 1);
+  }
+
+  const decodedPath = decodeGitPath(currentPath);
+  return decodedPath?.startsWith('b/') ? decodedPath.slice(2) : null;
+}
+
+function isCompleteHunkPatch(lines: readonly string[]): boolean {
+  let oldLinesRemaining = 0;
+  let newLinesRemaining = 0;
+  let hasHunk = false;
+
+  for (const line of lines) {
+    const header = line.match(/^@@ -\d+(?:,(\d+))? \+\d+(?:,(\d+))? @@/);
+    if (header) {
+      if (hasHunk && (oldLinesRemaining !== 0 || newLinesRemaining !== 0)) return false;
+      oldLinesRemaining = parseInt(header[1] ?? '1', 10);
+      newLinesRemaining = parseInt(header[2] ?? '1', 10);
+      hasHunk = true;
+      continue;
+    }
+
+    if (!hasHunk || isNoNewlineMarker(line)) continue;
+    if (line.startsWith(' ')) {
+      oldLinesRemaining--;
+      newLinesRemaining--;
+    } else if (line.startsWith('-')) {
+      oldLinesRemaining--;
+    } else if (line.startsWith('+')) {
+      newLinesRemaining--;
+    } else {
+      return false;
+    }
+
+    if (oldLinesRemaining < 0 || newLinesRemaining < 0) return false;
+  }
+
+  return hasHunk && oldLinesRemaining === 0 && newLinesRemaining === 0;
+}
+
+function getFilePatchFromSection(lines: readonly string[]): string | null {
+  const hunkIndex = lines.findIndex((line) => line.startsWith('@@'));
+  if (hunkIndex >= 0) {
+    const patchLines = lines.slice(hunkIndex);
+    if (patchLines.at(-1) === '') patchLines.pop();
+    return isCompleteHunkPatch(patchLines) ? patchLines.join('\n') : null;
+  }
+
+  const binaryLines = lines.filter((line) =>
+    line === 'GIT binary patch' || /^Binary files .+ differ$/.test(line),
+  );
+  if (binaryLines.length > 0) return binaryLines.join('\n');
+
+  const hasKnownEmptyBlob = lines.some((line) =>
+    /^index (?:0+\.\.e69de29[0-9a-f]*|e69de29[0-9a-f]*\.\.0+)(?: |$)/.test(line)
+  );
+  const isExactRename = lines.includes('similarity index 100%');
+  const isKnownContentFreeChange = hasKnownEmptyBlob || isExactRename;
+  return isKnownContentFreeChange ? '' : null;
+}
+
+function parsePullRequestDiff(diff: string): ReadonlyMap<string, string> {
+  const sections: string[][] = [];
+  let currentSection: string[] | undefined;
+
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('diff --git ')) {
+      currentSection = [line];
+      sections.push(currentSection);
+    } else {
+      currentSection?.push(line);
+    }
+  }
+
+  const patches = new Map<string, string>();
+  for (const section of sections) {
+    const [diffHeader] = section as [string, ...string[]];
+    const currentPathLine = section.find((line) => line.startsWith('+++ '));
+    const previousPathLine = section.find((line) => line.startsWith('--- '));
+    const currentFilename = currentPathLine === undefined
+      ? null
+      : getDiffHeaderFilename(currentPathLine);
+    const previousFilename = previousPathLine === undefined
+      ? null
+      : getDiffHeaderFilename(previousPathLine);
+    const filename = currentFilename ?? previousFilename ?? getDiffGitFilename(diffHeader);
+    const patch = getFilePatchFromSection(section);
+    if (filename !== null && patch !== null) patches.set(filename, patch);
+  }
+
+  return patches;
+}
+
+export function recoverFilePatchesFromDiff(
+  files: readonly PullRequestFile[],
+  diff: string,
+): PullRequestFile[] {
+  const patches = parsePullRequestDiff(diff);
+  return files.map((file) => {
+    const state = analyzeFile(file).state;
+    if (state !== 'missing-patch' && state !== 'failed') return file;
+    const patch = patches.get(file.filename);
+    return patch === undefined ? file : { ...file, patch };
+  });
 }
 
 function countAnalyses(files: readonly FileDiffAnalysis[]): DiffAnalysisCounts {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -11,13 +11,15 @@ import type { PullRequestFile, PullRequestReviewComment, ReviewComment } from '.
 describe('listPullRequestFiles', () => {
   it('paginates pull request files with a page size of 100', async () => {
     const files: PullRequestFile[] = [
-      { filename: 'policy-1.tf', patch: '+ "s3:Get*"' },
-      { filename: 'policy-2.tf', patch: '+ "ec2:Describe*"' },
+      { filename: 'policy-1.tf', patch: '@@ -0,0 +1 @@\n+"s3:Get*"' },
+      { filename: 'policy-2.tf', patch: '@@ -0,0 +1 @@\n+"ec2:Describe*"' },
     ];
     const listFiles = {};
     const paginate = vi.fn().mockResolvedValue(files);
+    const request = vi.fn();
     const octokit = {
       paginate,
+      request,
       rest: {
         pulls: {
           listFiles,
@@ -34,6 +36,79 @@ describe('listPullRequestFiles', () => {
       pull_number: 42,
       per_page: 100,
     });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('recovers omitted file patches from the full pull request diff', async () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf' },
+      { filename: 'complete.tf', patch: '@@ -1 +1 @@\n+"s3:Get*"' },
+    ];
+    const listFiles = {};
+    const request = vi.fn().mockResolvedValue({
+      data: `diff --git a/policy.tf b/policy.tf
+--- a/policy.tf
++++ b/policy.tf
+@@ -1 +1 @@
+-"s3:GetObject"
++"s3:Get*"`,
+    });
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue(files),
+      request,
+      rest: { pulls: { listFiles } },
+    };
+
+    const result = await listPullRequestFiles(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    );
+
+    expect(result[0]?.patch).toBe('@@ -1 +1 @@\n-"s3:GetObject"\n+"s3:Get*"');
+    expect(result[1]).toBe(files[1]);
+    expect(request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}',
+      {
+        owner: 'thekbb',
+        repo: 'expand-aws-iam-wildcards',
+        pull_number: 42,
+        headers: { accept: 'application/vnd.github.diff' },
+      },
+    );
+  });
+
+  it('keeps omitted patches explicit when full-diff retrieval fails', async () => {
+    const files: PullRequestFile[] = [{ filename: 'policy.tf' }];
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue(files),
+      request: vi.fn().mockRejectedValue(new Error('Resource not accessible by integration')),
+      rest: { pulls: { listFiles: {} } },
+    };
+
+    await expect(listPullRequestFiles(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    )).resolves.toEqual(files);
+  });
+
+  it('ignores an unexpected non-diff fallback response', async () => {
+    const files: PullRequestFile[] = [{ filename: 'policy.tf' }];
+    const octokit = {
+      paginate: vi.fn().mockResolvedValue(files),
+      request: vi.fn().mockResolvedValue({ data: { message: 'unexpected response' } }),
+      rest: { pulls: { listFiles: {} } },
+    };
+
+    await expect(listPullRequestFiles(
+      octokit,
+      'thekbb',
+      'expand-aws-iam-wildcards',
+      42,
+    )).resolves.toEqual(files);
   });
 });
 
@@ -508,6 +583,50 @@ describe('syncReviewComments', () => {
       repo: 'expand-aws-iam-wildcards',
       comment_id: 1001,
     });
+  });
+
+  it('updates known comments but preserves stale comments after incomplete analysis', async () => {
+    const octokit = makeOctokit();
+
+    const result = await syncReviewComments(octokit, {
+      ...baseParams,
+      comments: [{
+        path: 'analyzed.tf',
+        line: 10,
+        body: '**IAM Wildcard Expansion**\n\nnew body',
+      }],
+      existingComments: [
+        {
+          id: 1001,
+          path: 'analyzed.tf',
+          line: 10,
+          body: '**IAM Wildcard Expansion**\n\nold body',
+        },
+        {
+          id: 1002,
+          path: 'missing.tf',
+          line: 20,
+          body: '**IAM Wildcard Expansion**\n\nstale body',
+        },
+      ],
+      deleteStaleComments: false,
+    });
+
+    expect(result).toEqual({
+      createdCount: 0,
+      updatedCount: 1,
+      unchangedCount: 0,
+      deletedCount: 0,
+      failedDeleteCount: 0,
+      preservedCount: 1,
+    });
+    expect(octokit.rest.pulls.updateReviewComment).toHaveBeenCalledWith({
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      comment_id: 1001,
+      body: '**IAM Wildcard Expansion**\n\nnew body',
+    });
+    expect(octokit.rest.pulls.deleteReviewComment).not.toHaveBeenCalled();
   });
 
   it('deletes duplicate comments when one exact match is kept', async () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,6 @@
 import type { PullRequestFile, PullRequestReviewComment, ReviewComment } from './types.js';
 import { hasCurrentCommentMarker, hasLegacyCommentShape } from './comment-identity.js';
+import { extractFromDiff, recoverFilePatchesFromDiff } from './diff.js';
 
 interface PaginatedPullsClient<TItem> {
   readonly paginate: (
@@ -25,6 +26,18 @@ interface PaginatedPullsClient<TItem> {
   readonly graphql?: (query: string) => Promise<{
     readonly viewer: { readonly login: string };
   }>;
+}
+
+interface PullRequestFilesClient extends PaginatedPullsClient<PullRequestFile> {
+  readonly request: (
+    route: string,
+    parameters: {
+      owner: string;
+      repo: string;
+      pull_number: number;
+      headers: { readonly accept: string };
+    },
+  ) => Promise<{ readonly data: unknown }>;
 }
 
 interface ReviewSyncClient {
@@ -60,6 +73,7 @@ export interface SyncReviewCommentsParams {
   readonly commitSha: string;
   readonly comments: ReviewComment[];
   readonly existingComments: readonly PullRequestReviewComment[];
+  readonly deleteStaleComments?: boolean;
 }
 
 export interface SyncReviewCommentsResult {
@@ -94,17 +108,36 @@ function getExistingCommentAnchorKey(comment: PullRequestReviewComment): string 
 }
 
 export async function listPullRequestFiles(
-  octokit: PaginatedPullsClient<PullRequestFile>,
+  octokit: PullRequestFilesClient,
   owner: string,
   repo: string,
   pullNumber: number,
 ): Promise<PullRequestFile[]> {
-  return octokit.paginate(octokit.rest.pulls.listFiles, {
+  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
     owner,
     repo,
     pull_number: pullNumber,
     per_page: 100,
   });
+
+  const needsFallback = extractFromDiff(files).files.some((file) =>
+    file.state === 'missing-patch' || file.state === 'failed',
+  );
+  if (!needsFallback) return files;
+
+  try {
+    const response = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+      owner,
+      repo,
+      pull_number: pullNumber,
+      headers: { accept: 'application/vnd.github.diff' },
+    });
+    return typeof response.data === 'string'
+      ? recoverFilePatchesFromDiff(files, response.data)
+      : files;
+  } catch {
+    return files;
+  }
 }
 
 export async function listActionReviewComments(
@@ -180,7 +213,15 @@ export async function syncReviewComments(
   octokit: ReviewSyncClient,
   params: SyncReviewCommentsParams,
 ): Promise<SyncReviewCommentsResult> {
-  const { owner, repo, pullNumber, commitSha, comments, existingComments } = params;
+  const {
+    owner,
+    repo,
+    pullNumber,
+    commitSha,
+    comments,
+    existingComments,
+    deleteStaleComments = true,
+  } = params;
   const existingCommentsByAnchor = new Map<string, PullRequestReviewComment[]>();
   const staleComments: PullRequestReviewComment[] = [];
 
@@ -268,7 +309,7 @@ export async function syncReviewComments(
   let preservedCount = 0;
 
   for (const comment of staleComments) {
-    if (comment.hasReplies) {
+    if (!deleteStaleComments || comment.hasReplies) {
       preservedCount += 1;
       continue;
     }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -70,6 +70,11 @@ describe('runAction integration', () => {
     });
   }
 
+  function setMissingPatch(): void {
+    files.length = 0;
+    files.push({ filename: fixturePath });
+  }
+
   const createReview = vi.fn(async (parameters: {
     owner: string;
     repo: string;
@@ -129,12 +134,14 @@ describe('runAction integration', () => {
 
     throw new Error('Unexpected paginate route');
   });
+  const request = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     reviewComments.length = 0;
     files.length = 0;
     nextCommentId = 1000;
+    request.mockRejectedValue(new Error('Full diff unavailable'));
 
     setWildcardPatch('s3:Get*Tagging');
 
@@ -154,6 +161,7 @@ describe('runAction integration', () => {
     githubMocks.getOctokit.mockReturnValue({
       paginate,
       graphql: vi.fn().mockResolvedValue({ viewer: { login: 'github-actions[bot]' } }),
+      request,
       rest: {
         pulls: {
           listFiles: listFilesRoute,
@@ -219,5 +227,32 @@ describe('runAction integration', () => {
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Deleted 1 existing comment(s) from previous runs',
     );
+  });
+
+  it('preserves an existing comment when fallback diff retrieval fails', async () => {
+    await runAction();
+
+    setMissingPatch();
+
+    await runAction();
+
+    expect(request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}',
+      {
+        owner: 'thekbb',
+        repo: 'expand-aws-iam-wildcards',
+        pull_number: 42,
+        headers: { accept: 'application/vnd.github.diff' },
+      },
+    );
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect(updateReviewComment).not.toHaveBeenCalled();
+    expect(deleteReviewComment).not.toHaveBeenCalled();
+    expect(reviewComments).toHaveLength(1);
+    expect(coreMocks.warning).toHaveBeenCalledWith(
+      'Diff analysis was incomplete for 1 file(s): 1 missing patch, 0 failed. '
+        + 'Stale comment deletion is disabled for this run.',
+    );
+    expect(coreMocks.info).toHaveBeenCalledWith('Preserved 1 stale comment thread(s)');
   });
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -138,6 +138,7 @@ describe('runAction', () => {
       commitSha: 'deadbeef',
       comments: [],
       existingComments: [],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith('No files matched the configured patterns.');
   });
@@ -188,6 +189,7 @@ describe('runAction', () => {
       commitSha: 'abc123',
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       existingComments: [{ id: 99 }],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Synchronized comments: 1 created, 0 updated, 0 unchanged',
@@ -360,6 +362,7 @@ describe('runAction', () => {
       commitSha: 'abc123',
       comments: [],
       existingComments: [],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Diff analysis: 2 analyzed, 0 binary, 0 empty, 0 missing patch, 0 failed',
@@ -395,14 +398,26 @@ describe('runAction', () => {
       },
       truncatedComments: [],
     });
+    githubApiMocks.listActionReviewComments.mockResolvedValue([{ id: 99 }]);
 
     await runAction();
+
+    expect(githubApiMocks.syncReviewComments).toHaveBeenCalledWith({ tag: 'octokit' }, {
+      owner: 'thekbb',
+      repo: 'expand-aws-iam-wildcards',
+      pullNumber: 42,
+      commitSha: 'abc123',
+      comments: [],
+      existingComments: [{ id: 99 }],
+      deleteStaleComments: false,
+    });
 
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Diff analysis: 1 analyzed, 0 binary, 0 empty, 1 missing patch, 1 failed',
     );
     expect(coreMocks.warning).toHaveBeenCalledWith(
-      'Diff analysis was incomplete for 2 file(s): 1 missing patch, 1 failed',
+      'Diff analysis was incomplete for 2 file(s): 1 missing patch, 1 failed. '
+        + 'Stale comment deletion is disabled for this run.',
     );
     expect(coreMocks.info).toHaveBeenCalledWith(
       'No IAM wildcard actions found in the analyzed files.',
@@ -439,6 +454,7 @@ describe('runAction', () => {
       commitSha: 'babecafe',
       comments: [],
       existingComments: [],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Diff analysis: 1 analyzed, 0 binary, 0 empty, 0 missing patch, 0 failed',
@@ -477,6 +493,7 @@ describe('runAction', () => {
       commitSha: 'badc0de',
       comments: [],
       existingComments: [],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Diff analysis: 1 analyzed, 0 binary, 0 empty, 0 missing patch, 0 failed',
@@ -523,6 +540,7 @@ describe('runAction', () => {
       commitSha: 'decafbad',
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       existingComments: [],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Synchronized comments: 1 created, 0 updated, 0 unchanged',
@@ -568,6 +586,7 @@ describe('runAction', () => {
       commitSha: 'badc0de',
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       existingComments: [],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Synchronized comments: 1 created, 0 updated, 0 unchanged',
@@ -615,12 +634,13 @@ describe('runAction', () => {
       commitSha: 'decafbad',
       comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
       existingComments: [],
+      deleteStaleComments: true,
     });
     expect(coreMocks.info).toHaveBeenCalledWith(
       'Synchronized comments: 1 created, 0 updated, 0 unchanged',
     );
     expect(coreMocks.info).toHaveBeenCalledWith(
-      'Preserved 2 stale comment thread(s) because they have replies',
+      'Preserved 2 stale comment thread(s)',
     );
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,9 +59,7 @@ function logReviewCommentSyncResult(result: SyncReviewCommentsResult): void {
   }
 
   if (result.preservedCount > 0) {
-    core.info(
-      `Preserved ${result.preservedCount} stale comment thread(s) because they have replies`,
-    );
+    core.info(`Preserved ${result.preservedCount} stale comment thread(s)`);
   }
 }
 
@@ -79,8 +77,10 @@ function logDiffAnalysis(stats: ProcessingStats): void {
   const incompleteCount = missingPatch + failed;
   if (incompleteCount > 0) {
     const incompleteSummary = `${missingPatch} missing patch, ${failed} failed`;
+    const incompleteMessage =
+      `Diff analysis was incomplete for ${incompleteCount} file(s): ${incompleteSummary}.`;
     core.warning(
-      `Diff analysis was incomplete for ${incompleteCount} file(s): ${incompleteSummary}`,
+      `${incompleteMessage} Stale comment deletion is disabled for this run.`,
     );
   }
 }
@@ -126,16 +126,20 @@ export async function runAction(): Promise<void> {
       collapseThreshold,
       reviewCommentOptions,
     );
+    const incompleteAnalysisCount = stats.fileAnalysis.missingPatch
+      + stats.fileAnalysis.failed;
+    const syncComments = (commentsToSync: typeof comments) => syncReviewComments(octokit, {
+      owner,
+      repo,
+      pullNumber,
+      commitSha,
+      comments: commentsToSync,
+      existingComments,
+      deleteStaleComments: incompleteAnalysisCount === 0,
+    });
 
     if (stats.filesMatched === 0) {
-      logReviewCommentSyncResult(await syncReviewComments(octokit, {
-        owner,
-        repo,
-        pullNumber,
-        commitSha,
-        comments: [],
-        existingComments,
-      }));
+      logReviewCommentSyncResult(await syncComments([]));
       core.info('No files matched the configured patterns.');
       return;
     }
@@ -143,14 +147,7 @@ export async function runAction(): Promise<void> {
     logDiffAnalysis(stats);
 
     if (stats.wildcardsFound === 0) {
-      logReviewCommentSyncResult(await syncReviewComments(octokit, {
-        owner,
-        repo,
-        pullNumber,
-        commitSha,
-        comments: [],
-        existingComments,
-      }));
+      logReviewCommentSyncResult(await syncComments([]));
       core.info('No IAM wildcard actions found in the analyzed files.');
       return;
     }
@@ -158,41 +155,20 @@ export async function runAction(): Promise<void> {
     core.info(`Found ${stats.wildcardsFound} wildcard(s), grouped into ${stats.blocksCreated} block(s)`);
 
     if (stats.actionsExpanded === 0) {
-      logReviewCommentSyncResult(await syncReviewComments(octokit, {
-        owner,
-        repo,
-        pullNumber,
-        commitSha,
-        comments: [],
-        existingComments,
-      }));
+      logReviewCommentSyncResult(await syncComments([]));
       core.info('No wildcard actions could be expanded.');
       return;
     }
 
     if (comments.length === 0) {
-      logReviewCommentSyncResult(await syncReviewComments(octokit, {
-        owner,
-        repo,
-        pullNumber,
-        commitSha,
-        comments: [],
-        existingComments,
-      }));
+      logReviewCommentSyncResult(await syncComments([]));
       core.info('No comments to post.');
       return;
     }
 
     logTruncatedComments(truncatedComments, workflowRunUrl);
 
-    const syncResult = await syncReviewComments(octokit, {
-      owner,
-      repo,
-      comments,
-      pullNumber,
-      commitSha,
-      existingComments,
-    });
+    const syncResult = await syncComments(comments);
     logReviewCommentSyncResult(syncResult);
   } catch (error) {
     core.setFailed(error instanceof Error ? error.message : 'An unexpected error occurred');


### PR DESCRIPTION
Recover missing or malformed patches from GitHub's full pull request diff. Keep partial findings and preserve stale comments when fallback retrieval is unavailable or incomplete. Cover permissions, truncation, multi-hunk diffs, binary and empty files, renames, removals, and quoted paths.