### PR TITLE
test pull request behavior in an isolated repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report analyzed, binary, empty, missing, and failed pull-request diff states
 - Recover omitted patches from the full pull-request diff and preserve stale comments if analysis remains incomplete
 - Exercise the compiled action lifecycle against a paginated local GitHub API fixture
+- Verify comment creation, reruns, updates, cleanup, and reply preservation in a controlled GitHub pull request
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,26 @@ local HTTP server. Together they cover pagination, comment creation, unchanged
 reruns, updates, stale cleanup, truncation, and no-op behavior through both the
 TypeScript modules and the generated action entry point.
 
+The manual `End-to-End Test` workflow lives in the dedicated
+[`thekbb/expand-aws-iam-wildcards-e2e`](https://github.com/thekbb/expand-aws-iam-wildcards-e2e)
+fixture repository and runs only from its `main` branch. It accepts a full
+commit SHA from this repository's `main` history, checks out and builds that
+exact source, and runs the compiled action against the real GitHub API. It
+verifies creation, unchanged reruns, in-place updates, stale cleanup, and reply
+preservation before closing the pull request and deleting its branch in an
+`always()` cleanup step.
+
+Before its first run, enable `Allow GitHub Actions to create and approve pull
+requests` under the fixture repository's Actions settings. Run `End-to-End
+Test` there with its `main` branch selected and provide the source commit as
+`source_sha`. The workflow uses only a job-scoped `GITHUB_TOKEN` with write
+access to the fixture repository; it does not require source-repository write
+access, a PAT, or a repository secret.
+
+The fixture branch is named `e2e/run-<run-id>-<attempt>`. If a runner-level
+cancellation prevents the cleanup step from running, close the draft fixture
+pull request and delete that exact branch manually.
+
 Generated review comments include a versioned HTML marker used for machine
 identity. The visible heading remains part of the legacy migration contract;
 change either marker only with collision, migration, and synchronization tests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,14 @@ comments from older releases are recognized by their generated body shape and
 migrated to the current machine marker in place. Stale comments are not deleted
 when pull-request diff analysis remains incomplete after fallback retrieval.
 
+## Hosted End-to-End Test
+
+The end-to-end workflow is manual-only and runs only from `main`. Its single
+job receives only `contents: write` and `pull-requests: write` through the
+short-lived `GITHUB_TOKEN`. It does not execute fork code or use a PAT. Every
+run creates a uniquely named draft fixture pull request, then closes the pull
+request and deletes its branch in an `always()` cleanup step.
+
 ## Release Verification
 
 Release tags are signed with a GPG key. The armored public key is published at

--- a/scripts/e2e/pull-request.test.ts
+++ b/scripts/e2e/pull-request.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACTION_COMMENT_MARKER,
+  assertRuntimeResult,
+  getActionParentComments,
+  getNextLink,
+  parseRepository,
+} from './pull-request.js';
+
+describe('pull request E2E helpers', () => {
+  it('parses one owner and repository name', () => {
+    expect(parseRepository('thekbb/expand-aws-iam-wildcards')).toEqual([
+      'thekbb',
+      'expand-aws-iam-wildcards',
+    ]);
+    expect(() => parseRepository('missing-repository')).toThrow(
+      'Expected E2E_REPOSITORY as owner/repo',
+    );
+    expect(() => parseRepository('owner/repo/extra')).toThrow(
+      'Expected E2E_REPOSITORY as owner/repo',
+    );
+    expect(() => parseRepository('owner/bad repo')).toThrow(
+      'Expected E2E_REPOSITORY as owner/repo',
+    );
+  });
+
+  it('finds the next pagination link', () => {
+    expect(getNextLink(null)).toBeNull();
+    expect(getNextLink(
+      '<https://api.github.com/page/1>; rel="prev", '
+        + '<https://api.github.com/page/3>; rel="next"',
+    )).toBe('https://api.github.com/page/3');
+    expect(getNextLink('<https://api.github.com/page/1>; rel="prev"')).toBeNull();
+  });
+
+  it('selects only marked parent comments on the fixture path', () => {
+    const comments = [
+      {
+        id: 1,
+        path: 'fixture.tf',
+        body: `body\n${ACTION_COMMENT_MARKER}`,
+        user: { type: 'Bot' },
+      },
+      {
+        id: 2,
+        path: 'fixture.tf',
+        body: ACTION_COMMENT_MARKER,
+        in_reply_to_id: 1,
+        user: { type: 'Bot' },
+      },
+      { id: 3, path: 'other.tf', body: ACTION_COMMENT_MARKER, user: { type: 'Bot' } },
+      {
+        id: 4,
+        path: 'fixture.tf',
+        body: `prefix ${ACTION_COMMENT_MARKER}`,
+        user: { type: 'Bot' },
+      },
+      { id: 5, path: 'fixture.tf', body: ACTION_COMMENT_MARKER, user: { type: 'User' } },
+    ];
+
+    expect(getActionParentComments(comments, 'fixture.tf').map((comment) => comment.id)).toEqual([
+      1,
+    ]);
+  });
+
+  it('requires successful runtime output', () => {
+    expect(() => assertRuntimeResult({
+      status: 0,
+      stderr: '',
+      stdout: 'created\nupdated',
+    }, ['created', 'updated'])).not.toThrow();
+    expect(() => assertRuntimeResult({
+      status: 1,
+      stderr: 'failed',
+      stdout: '',
+    }, [])).toThrow('E2E action failed with exit status 1: failed');
+    expect(() => assertRuntimeResult({
+      status: 0,
+      stderr: '',
+      stdout: 'created',
+    }, ['updated'])).toThrow('E2E action output omitted: updated');
+    const error = new Error('spawn failed');
+    expect(() => assertRuntimeResult({
+      error,
+      status: null,
+      stderr: '',
+      stdout: '',
+    }, [])).toThrow(error);
+  });
+});

--- a/scripts/e2e/pull-request.ts
+++ b/scripts/e2e/pull-request.ts
@@ -1,0 +1,403 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { resolveActionRuntime } from '../release/smoke.js';
+
+export const ACTION_COMMENT_MARKER =
+  '<!-- expand-aws-iam-wildcards:review-comment:v1 -->';
+const API_VERSION = '2026-03-10';
+const REQUEST_TIMEOUT_MS = 15_000;
+const RUNTIME_TIMEOUT_MS = 60_000;
+const MAX_RUNTIME_OUTPUT = 2_000_000;
+const MAX_PAGINATION_PAGES = 20;
+const RETRY_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 1_000;
+
+export interface ReviewComment {
+  readonly id: number;
+  readonly body?: string;
+  readonly path?: string;
+  readonly line?: number | null;
+  readonly in_reply_to_id?: number | null;
+  readonly user?: {
+    readonly type?: string | null;
+  } | null;
+}
+
+interface PullRequestFixture {
+  readonly apiUrl: string;
+  readonly eventPath: string;
+  readonly fixturePath: string;
+  readonly headSha: string;
+  readonly owner: string;
+  readonly pullNumber: number;
+  readonly repo: string;
+  readonly repository: string;
+  readonly runtime: string;
+  readonly token: string;
+}
+
+interface RuntimeResult {
+  readonly error?: Error;
+  readonly status: number | null;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+export function parseRepository(repository: string): readonly [string, string] {
+  const parts = repository.split('/');
+  if (parts.length !== 2 || parts.some((part) => !/^[A-Za-z0-9_.-]+$/.test(part))) {
+    throw new Error(`Expected E2E_REPOSITORY as owner/repo, got: ${repository}`);
+  }
+  return parts as [string, string];
+}
+
+function parsePullNumber(value: string): number {
+  const pullNumber = Number(value);
+  if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error(`Expected E2E_PR_NUMBER as a positive integer, got: ${value}`);
+  }
+  return pullNumber;
+}
+
+function parseHeadSha(value: string): string {
+  if (!/^[0-9a-f]{40}$/.test(value)) {
+    throw new Error(`Expected E2E_HEAD_SHA as a full commit SHA, got: ${value}`);
+  }
+  return value;
+}
+
+export function getNextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+
+  for (const entry of linkHeader.split(',')) {
+    const match = entry.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+    if (match?.[2] === 'next') return match[1] ?? null;
+  }
+  return null;
+}
+
+export function getActionParentComments(
+  comments: readonly ReviewComment[],
+  fixturePath: string,
+): ReviewComment[] {
+  return comments.filter((comment) =>
+    (comment.in_reply_to_id === null || comment.in_reply_to_id === undefined)
+      && comment.path === fixturePath
+      && comment.user?.type === 'Bot'
+      && comment.body?.split(/\r?\n/).includes(ACTION_COMMENT_MARKER) === true
+  );
+}
+
+function formatOutput(result: RuntimeResult): string {
+  return [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
+}
+
+export function assertRuntimeResult(
+  result: RuntimeResult,
+  expectedOutput: readonly string[],
+): void {
+  if (result.error !== undefined) throw result.error;
+  const output = formatOutput(result);
+  if (result.status !== 0) {
+    throw new Error(`E2E action failed with exit status ${result.status ?? 1}: ${output}`);
+  }
+  for (const expected of expectedOutput) {
+    if (!result.stdout.includes(expected)) {
+      throw new Error(`E2E action output omitted: ${expected}\n${output}`);
+    }
+  }
+}
+
+function assertSameIds(
+  expected: readonly ReviewComment[],
+  actual: readonly ReviewComment[],
+  phase: string,
+): void {
+  const expectedIds = expected.map((comment) => comment.id).toSorted((a, b) => a - b);
+  const actualIds = actual.map((comment) => comment.id).toSorted((a, b) => a - b);
+  if (JSON.stringify(actualIds) !== JSON.stringify(expectedIds)) {
+    throw new Error(
+      `${phase} changed comment IDs: expected ${expectedIds.join(', ')}, got ${actualIds.join(', ')}`,
+    );
+  }
+}
+
+function assertParentCount(
+  comments: readonly ReviewComment[],
+  fixturePath: string,
+  expectedCount: number,
+  phase: string,
+): ReviewComment[] {
+  const parents = getActionParentComments(comments, fixturePath);
+  if (parents.length !== expectedCount) {
+    throw new Error(`${phase} expected ${expectedCount} action comments, found ${parents.length}`);
+  }
+  return parents;
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function githubRequest<T>(
+  fixture: PullRequestFixture,
+  pathOrUrl: string,
+  init: RequestInit = {},
+): Promise<{ readonly data: T; readonly headers: Headers }> {
+  const apiBase = fixture.apiUrl.endsWith('/') ? fixture.apiUrl : `${fixture.apiUrl}/`;
+  const url = new URL(pathOrUrl.replace(/^\/+/, ''), apiBase);
+  const apiOrigin = new URL(fixture.apiUrl).origin;
+  if (url.origin !== apiOrigin) throw new Error(`Refusing E2E API redirect to ${url.origin}`);
+
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${fixture.token}`,
+      'content-type': 'application/json',
+      'user-agent': 'expand-aws-iam-wildcards-e2e',
+      'x-github-api-version': API_VERSION,
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const responseBody = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${init.method ?? 'GET'} ${url.pathname} failed with HTTP ${response.status}: ${responseBody}`,
+    );
+  }
+
+  return {
+    data: (responseBody === '' ? undefined : JSON.parse(responseBody)) as T,
+    headers: response.headers,
+  };
+}
+
+async function listReviewComments(fixture: PullRequestFixture): Promise<ReviewComment[]> {
+  const comments: ReviewComment[] = [];
+  const visitedUrls = new Set<string>();
+  let url: string | null =
+    `/repos/${fixture.owner}/${fixture.repo}/pulls/${fixture.pullNumber}/comments?per_page=100`;
+
+  while (url !== null) {
+    if (visitedUrls.has(url) || visitedUrls.size >= MAX_PAGINATION_PAGES) {
+      throw new Error('GitHub review-comment pagination did not terminate');
+    }
+    visitedUrls.add(url);
+    const response = await githubRequest<ReviewComment[]>(fixture, url);
+    if (!Array.isArray(response.data)) throw new Error('GitHub returned invalid review comments');
+    comments.push(...response.data);
+    url = getNextLink(response.headers.get('link'));
+  }
+  return comments;
+}
+
+async function waitForParentCount(
+  fixture: PullRequestFixture,
+  expectedCount: number,
+  phase: string,
+): Promise<{ readonly comments: ReviewComment[]; readonly parents: ReviewComment[] }> {
+  let comments: ReviewComment[] = [];
+
+  for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+    comments = await listReviewComments(fixture);
+    const parents = getActionParentComments(comments, fixture.fixturePath);
+    if (parents.length === expectedCount) return { comments, parents };
+    if (attempt < RETRY_ATTEMPTS) await delay(RETRY_DELAY_MS);
+  }
+
+  assertParentCount(comments, fixture.fixturePath, expectedCount, phase);
+  throw new Error('unreachable parent count assertion');
+}
+
+function runAction(
+  fixture: PullRequestFixture,
+  collapseThreshold: number,
+  filePatterns: string,
+  expectedOutput: readonly string[],
+): void {
+  const childEnvironment: NodeJS.ProcessEnv = {};
+  const passThroughEnvironment = [
+    'GITHUB_ACTIONS',
+    'GITHUB_API_URL',
+    'GITHUB_GRAPHQL_URL',
+    'GITHUB_REPOSITORY',
+    'GITHUB_RUN_ID',
+    'GITHUB_SERVER_URL',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'NODE_EXTRA_CA_CERTS',
+    'NO_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'no_proxy',
+  ] as const;
+  for (const name of passThroughEnvironment) {
+    const value = process.env[name];
+    if (value !== undefined) childEnvironment[name] = value;
+  }
+  Object.assign(childEnvironment, {
+    GITHUB_EVENT_NAME: 'pull_request',
+    GITHUB_EVENT_PATH: fixture.eventPath,
+    GITHUB_SHA: fixture.headSha,
+    'INPUT_COLLAPSE-THRESHOLD': String(collapseThreshold),
+    'INPUT_FILE-PATTERNS': filePatterns,
+    'INPUT_GITHUB-TOKEN': fixture.token,
+  });
+
+  const result = spawnSync(process.execPath, [fixture.runtime], {
+    encoding: 'utf8',
+    env: childEnvironment,
+    maxBuffer: MAX_RUNTIME_OUTPUT,
+    timeout: RUNTIME_TIMEOUT_MS,
+  });
+  const runtimeResult: RuntimeResult = {
+    status: result.status,
+    stderr: result.stderr ?? '',
+    stdout: result.stdout ?? '',
+    ...(result.error === undefined ? {} : { error: result.error }),
+  };
+  process.stdout.write(runtimeResult.stdout);
+  process.stderr.write(runtimeResult.stderr);
+  assertRuntimeResult(runtimeResult, expectedOutput);
+}
+
+async function createReply(
+  fixture: PullRequestFixture,
+  commentId: number,
+): Promise<ReviewComment> {
+  const response = await githubRequest<ReviewComment>(
+    fixture,
+    `/repos/${fixture.owner}/${fixture.repo}/pulls/${fixture.pullNumber}/comments/${commentId}/replies`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ body: `Automated E2E reply from run ${process.env.GITHUB_RUN_ID ?? 'unknown'}.` }),
+    },
+  );
+  return response.data;
+}
+
+function loadFixture(eventPath: string): PullRequestFixture {
+  const repository = requiredEnvironment('E2E_REPOSITORY');
+  const [owner, repo] = parseRepository(repository);
+  const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+  const actionYaml = readFileSync(join(repositoryRoot, 'action.yml'), 'utf8');
+  const outputDirectory = join(repositoryRoot, 'dist');
+  const runtime = resolveActionRuntime(actionYaml, outputDirectory);
+
+  return {
+    apiUrl: process.env.GITHUB_API_URL ?? 'https://api.github.com',
+    eventPath,
+    fixturePath: requiredEnvironment('E2E_FIXTURE_PATH'),
+    headSha: parseHeadSha(requiredEnvironment('E2E_HEAD_SHA')),
+    owner,
+    pullNumber: parsePullNumber(requiredEnvironment('E2E_PR_NUMBER')),
+    repo,
+    repository,
+    runtime,
+    token: requiredEnvironment('E2E_TOKEN'),
+  };
+}
+
+export async function runPullRequestE2e(): Promise<void> {
+  const eventDirectory = mkdtempSync(join(tmpdir(), 'expand-aws-iam-wildcards-e2e-'));
+  const eventPath = join(eventDirectory, 'event.json');
+
+  try {
+    const fixture = loadFixture(eventPath);
+    writeFileSync(eventPath, JSON.stringify({
+      pull_request: {
+        number: fixture.pullNumber,
+        head: { sha: fixture.headSha },
+      },
+      repository: { full_name: fixture.repository },
+    }));
+
+    console.log('E2E phase: create comments');
+    runAction(fixture, 100, fixture.fixturePath, [
+      'Synchronized comments: 2 created, 0 updated, 0 unchanged',
+    ]);
+    const first = await waitForParentCount(fixture, 2, 'create');
+    if (first.parents.some((comment) => comment.body?.includes('<details>'))) {
+      throw new Error('create phase unexpectedly collapsed an action list');
+    }
+
+    console.log('E2E phase: unchanged rerun');
+    runAction(fixture, 100, fixture.fixturePath, [
+      'Synchronized comments: 0 created, 0 updated, 2 unchanged',
+    ]);
+    const rerun = await waitForParentCount(fixture, 2, 'rerun');
+    assertSameIds(first.parents, rerun.parents, 'rerun');
+    const firstBodies = first.parents.map((comment) => comment.body).toSorted();
+    const rerunBodies = rerun.parents.map((comment) => comment.body).toSorted();
+    if (JSON.stringify(firstBodies) !== JSON.stringify(rerunBodies)) {
+      throw new Error('unchanged rerun modified an action comment body');
+    }
+
+    console.log('E2E phase: update comments in place');
+    runAction(fixture, 1, fixture.fixturePath, [
+      'Synchronized comments: 0 created, 2 updated, 0 unchanged',
+    ]);
+    const updated = await waitForParentCount(fixture, 2, 'update');
+    assertSameIds(first.parents, updated.parents, 'update');
+    if (updated.parents.some((comment) => !comment.body?.includes('<details>'))) {
+      throw new Error('update phase did not collapse every action list');
+    }
+
+    const [protectedParent, unprotectedParent] = updated.parents.toSorted((a, b) =>
+      (a.line ?? 0) - (b.line ?? 0)
+    );
+    if (!protectedParent || !unprotectedParent) {
+      throw new Error('update phase did not return two comment anchors');
+    }
+
+    console.log('E2E phase: add a real review reply');
+    const reply = await createReply(fixture, protectedParent.id);
+    if (reply.in_reply_to_id !== protectedParent.id) {
+      throw new Error(`GitHub created reply ${reply.id} without the expected parent`);
+    }
+
+    console.log('E2E phase: delete stale comments while preserving replied threads');
+    runAction(fixture, 1, '**/*.never', [
+      'Deleted 1 existing comment(s) from previous runs',
+      'Preserved 1 stale comment thread(s)',
+      'No files matched the configured patterns.',
+    ]);
+    const cleaned = await waitForParentCount(fixture, 1, 'cleanup');
+    if (cleaned.parents[0]?.id !== protectedParent.id) {
+      throw new Error('cleanup did not preserve the replied action comment');
+    }
+    if (cleaned.comments.some((comment) => comment.id === unprotectedParent.id)) {
+      throw new Error('cleanup did not delete the unreplied action comment');
+    }
+    if (!cleaned.comments.some((comment) =>
+      comment.id === reply.id && comment.in_reply_to_id === protectedParent.id
+    )) {
+      throw new Error('cleanup did not preserve the review reply');
+    }
+
+    console.log(`E2E lifecycle passed for pull request #${fixture.pullNumber}.`);
+  } finally {
+    rmSync(eventDirectory, { force: true, recursive: true });
+  }
+}
+
+const entryPoint = process.argv[1] === undefined
+  ? undefined
+  : pathToFileURL(resolve(process.argv[1])).href;
+if (entryPoint === import.meta.url) {
+  void runPullRequestE2e().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Adds a real GitHub pull request lifecycle test for comment creation, reruns, in-place updates, stale cleanup, and replied-thread preservation.

Runs the hosted fixture in [expand-aws-iam-wildcards-e2e](https://github.com/thekbb/expand-aws-iam-wildcards-e2e) so temporary state and write permissions stay out of this one.