### PR TITLE
add test coverage thresholds so codecov will stop whining

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -83,7 +83,7 @@ jobs:
         run: npm run typecheck
 
       - name: Run unit tests
-        run: npm test -- --coverage
+        run: npm run test:coverage
 
       - name: Update package version
         env:

--- a/.github/workflows/verify-draft-release.yml
+++ b/.github/workflows/verify-draft-release.yml
@@ -143,7 +143,7 @@ jobs:
         run: npm run typecheck
 
       - name: Run unit tests
-        run: npm test -- --coverage
+        run: npm run test:coverage
 
       - name: Verify deterministic action bundle
         run: npm run build:check

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from 'vitest/config';
 
+export const COVERAGE_THRESHOLDS = {
+  statements: 95,
+  branches: 95,
+  functions: 100,
+  lines: 95,
+};
+
 export default defineConfig({
   test: {
     globals: true,
@@ -9,6 +16,7 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
       provider: 'v8',
+      thresholds: COVERAGE_THRESHOLDS,
       include: [
         'src/**/*.ts',
         'scripts/docs-contract.ts',


### PR DESCRIPTION
Adds Vitest coverage thresholds for source and release tooling, with functions held at 100% and the other coverage gates at 95%.

Also converges release workflows on npm run test:coverage so local checks, CI, and release verification use the same named coverage command.