### PR TITLE
add script to check release candidate files and working copy

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Build action bundle on Linux
         run: npm run build
 
+      - name: Check release-managed files
+        run: npm run release:check-files
+
       - name: Create or update the release preparation branch
         env:
           GH_TOKEN: ${{ secrets.IAM_UPDATE_PAT }}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:md": "markdownlint '**/*.md' --ignore node_modules",
     "prepare": "npm run generate-iam-data",
     "release": "tsx scripts/release.ts",
+    "release:check-files": "tsx scripts/check-release-files.ts",
     "release:report-iam-data": "tsx scripts/report-iam-data.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/check-release-files.ts
+++ b/scripts/check-release-files.ts
@@ -1,0 +1,12 @@
+import { defaultRuntime, requireCommand } from './release/command.js';
+import { checkReleaseManagedFiles } from './release/managed-files.js';
+
+const runtime = defaultRuntime(console);
+
+try {
+  requireCommand(runtime, 'git');
+  checkReleaseManagedFiles(runtime);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/release/managed-files.test.ts
+++ b/scripts/release/managed-files.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { type CommandResult, type ReleaseRuntime } from './command.js';
+import {
+  assertOnlyReleaseManagedFilesChanged,
+  checkReleaseManagedFiles,
+  RELEASE_MANAGED_FILES,
+  unexpectedReleaseFiles,
+} from './managed-files.js';
+
+function runtime(result: CommandResult): ReleaseRuntime {
+  return {
+    env: {},
+    promptEnter: () => undefined,
+    run: () => result,
+    sleep: () => undefined,
+    stdinIsTTY: false,
+    stdout: console,
+  };
+}
+
+describe('release-managed files', () => {
+  it('allows only release preparation files', () => {
+    expect(RELEASE_MANAGED_FILES).toEqual([
+      'CHANGELOG.md',
+      'dist/index.js',
+      'package-lock.json',
+      'package.json',
+    ]);
+    expect(unexpectedReleaseFiles([
+      ' M CHANGELOG.md',
+      ' M dist/index.js',
+      ' M package-lock.json',
+      ' M package.json',
+      '',
+    ].join('\n'))).toEqual([]);
+  });
+
+  it('reports unexpected, untracked, duplicate, and renamed paths once', () => {
+    expect(unexpectedReleaseFiles([
+      ' M README.md',
+      '?? notes.txt',
+      ' M README.md',
+      'R  docs/old.md -> docs/new.md',
+      ' M package.json',
+    ].join('\n'))).toEqual([
+      'README.md',
+      'docs/new.md',
+      'notes.txt',
+    ]);
+  });
+
+  it('throws a precise error for unmanaged release changes', () => {
+    expect(() => assertOnlyReleaseManagedFilesChanged(' M README.md\n M src/main.ts\n')).toThrow(
+      'Release preparation changed unmanaged file(s): README.md, src/main.ts',
+    );
+  });
+
+  it('checks the current git status through the release runtime', () => {
+    expect(() => checkReleaseManagedFiles(runtime({
+      status: 0,
+      stderr: '',
+      stdout: ' M package.json\n M dist/index.js\n',
+    }))).not.toThrow();
+
+    expect(() => checkReleaseManagedFiles(runtime({
+      status: 0,
+      stderr: '',
+      stdout: ' M README.md\n',
+    }))).toThrow('Release preparation changed unmanaged file(s): README.md');
+  });
+
+  it('reports git status failures', () => {
+    expect(() => checkReleaseManagedFiles(runtime({
+      status: 128,
+      stderr: 'not a git repository',
+      stdout: '',
+    }))).toThrow('git status --porcelain --untracked-files=all failed: not a git repository');
+  });
+});

--- a/scripts/release/managed-files.ts
+++ b/scripts/release/managed-files.ts
@@ -1,0 +1,47 @@
+import { type ReleaseRuntime, runChecked } from './command.js';
+
+export const RELEASE_MANAGED_FILES = [
+  'CHANGELOG.md',
+  'dist/index.js',
+  'package-lock.json',
+  'package.json',
+];
+
+function statusPath(line: string): string {
+  const path = line.slice(3);
+  const renameSeparator = ' -> ';
+  const renameIndex = path.indexOf(renameSeparator);
+  return renameIndex === -1 ? path : path.slice(renameIndex + renameSeparator.length);
+}
+
+export function unexpectedReleaseFiles(
+  porcelainStatus: string,
+  managedFiles: readonly string[] = RELEASE_MANAGED_FILES,
+): string[] {
+  const allowed = new Set(managedFiles);
+  return [...new Set(porcelainStatus
+    .split('\n')
+    .filter((line) => line !== '')
+    .map(statusPath)
+    .filter((path) => !allowed.has(path)))]
+    .sort();
+}
+
+export function assertOnlyReleaseManagedFilesChanged(
+  porcelainStatus: string,
+  managedFiles: readonly string[] = RELEASE_MANAGED_FILES,
+): void {
+  const unexpected = unexpectedReleaseFiles(porcelainStatus, managedFiles);
+  if (unexpected.length > 0) {
+    throw new Error(`Release preparation changed unmanaged file(s): ${unexpected.join(', ')}`);
+  }
+}
+
+export function checkReleaseManagedFiles(runtime: ReleaseRuntime): void {
+  const status = runChecked(runtime, 'git', [
+    'status',
+    '--porcelain',
+    '--untracked-files=all',
+  ]).stdout;
+  assertOnlyReleaseManagedFilesChanged(status);
+}


### PR DESCRIPTION
Adds a release preparation guard that fails if the workflow changes files outside the managed release set.

the prepare workflow now checks the working tree before staging, so unexpected generated files or source changes cannot enter a release-candidate branch by accident.