### PR TITLE
Refresh release candidate pull requests

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,8 +15,8 @@ on:
         type: boolean
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: prepare-release-v${{ inputs.version }}
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: automation
     steps:
@@ -87,38 +88,23 @@ jobs:
       - name: Check release-managed files
         run: npm run release:check-files
 
-      - name: Create or update the release preparation branch
-        env:
-          GH_TOKEN: ${{ secrets.IAM_UPDATE_PAT }}
-          IAM_ACTION_COUNT: ${{ steps.iam_data.outputs.action_count }}
-          IAM_DATA_VERSION: ${{ steps.iam_data.outputs.version }}
-          IAM_SERVICE_COUNT: ${{ steps.iam_data.outputs.service_count }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          BRANCH="release-candidate/v${VERSION}"
-          BODY="Uses locked IAM data ${IAM_DATA_VERSION} with ${IAM_ACTION_COUNT} actions across ${IAM_SERVICE_COUNT} services, generates the release bundle on Ubuntu, and updates package metadata for v${VERSION}."
-          git switch -c "$BRANCH"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md package.json package-lock.json dist/index.js
-
-          if git diff --cached --quiet; then
-            echo "No release preparation changes were generated."
-            exit 1
-          fi
-
-          git commit -m "Prepare v${VERSION} release"
-          git push --force-with-lease "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH}"
-
-          pr_number="$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number // empty')"
-          if [[ -n "$pr_number" ]]; then
-            gh pr edit "$pr_number" --body "$BODY"
-            echo "Updated existing release preparation PR #$pr_number"
-            exit 0
-          fi
-
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "Prepare v${VERSION} release" \
-            --body "$BODY"
+      - name: Create or update the release preparation pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.IAM_UPDATE_PAT }}
+          base: main
+          branch: release-candidate/v${{ inputs.version }}
+          delete-branch: true
+          title: Prepare v${{ inputs.version }} release
+          commit-message: Prepare v${{ inputs.version }} release
+          body: |
+            Uses locked IAM data ${{ steps.iam_data.outputs.version }} with
+            ${{ steps.iam_data.outputs.action_count }} actions across
+            ${{ steps.iam_data.outputs.service_count }} services, generates the
+            release bundle on Ubuntu, and updates package metadata for
+            v${{ inputs.version }}.
+          add-paths: |
+            CHANGELOG.md
+            dist/index.js
+            package-lock.json
+            package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recover omitted patches from the full pull-request diff and preserve stale comments if analysis remains incomplete
 - Exercise the compiled action lifecycle against a paginated local GitHub API fixture
 - Verify comment creation, reruns, updates, cleanup, and reply preservation in a controlled GitHub pull request
+- Make release-candidate reruns refresh the existing pull request with an explicit file allowlist
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,6 @@ prepare workflow.
    grep -q "^## \\[UNRELEASED\\]" CHANGELOG.md
    ! git rev-parse -q --verify "refs/tags/$TAG"
    ! git ls-remote --exit-code --tags origin "$TAG"
-   ! git ls-remote --exit-code --heads origin "$BRANCH"
    ```
 
    Instead of running the preflight checks and `Prepare Release` commands manually, use the release command. It waits
@@ -220,6 +219,10 @@ prepare workflow.
    ```
 
 4. Review and merge the resulting `$BRANCH` pull request.
+
+   Rerunning `Prepare Release` for the same version refreshes the existing open
+   pull request from `main`. The workflow limits the candidate commit to
+   `CHANGELOG.md`, `dist/index.js`, `package.json`, and `package-lock.json`.
 
    If you stopped the script after creating the release preparation PR, resume after merging the pull request:
 

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -348,7 +348,7 @@ describe('runReleaseCli', () => {
     expect(errors).toEqual(['error: working tree must be clean']);
   });
 
-  it('rejects prepare mode when the remote release candidate branch exists', () => {
+  it('rejects prepare mode when the remote release candidate branch has no open pull request', () => {
     const errors: string[] = [];
     const { runtime } = createRuntime(
       new Map([
@@ -367,6 +367,10 @@ describe('runReleaseCli', () => {
         ['git rev-parse -q --verify refs/tags/v1.3.0', [result('', 1)]],
         ['git ls-remote --exit-code origin refs/tags/v1.3.0', [result('', 2)]],
         ['git ls-remote --exit-code origin refs/heads/release-candidate/v1.3.0', [result('branch\n')]],
+        [
+          'gh pr list --state all --head release-candidate/v1.3.0 --base main --json state',
+          [result('[]')],
+        ],
       ]),
     );
 
@@ -378,7 +382,60 @@ describe('runReleaseCli', () => {
     });
 
     expect(exitCode).toBe(1);
-    expect(errors).toEqual(['error: remote release candidate branch already exists: release-candidate/v1.3.0']);
+    expect(errors).toEqual([
+      'error: remote release candidate branch has no open pull request: release-candidate/v1.3.0',
+    ]);
+  });
+
+  it('refreshes an existing open release candidate pull request', () => {
+    const errors: string[] = [];
+    const { calls, output, runtime } = createRuntime(
+      new Map([
+        ['which git', [result()]],
+        ['which gh', [result()]],
+        ['which gpg', [result()]],
+        ['gh auth status', [result()]],
+        ['git branch --show-current', [result('main\n')]],
+        ['git fetch origin main --tags', [result()]],
+        ['git rev-parse HEAD', [result(`${releaseSha}\n`)]],
+        ['git rev-parse origin/main', [result(`${releaseSha}\n`)]],
+        ['git status --porcelain', [result('')]],
+        ['git config --get user.signingkey', [result('ABC123\n')]],
+        ['gpg --list-secret-keys ABC123', [result()]],
+        ['git show HEAD:CHANGELOG.md', [result('## [UNRELEASED]\n')]],
+        ['git rev-parse -q --verify refs/tags/v1.3.0', [result('', 1)]],
+        ['git ls-remote --exit-code origin refs/tags/v1.3.0', [result('', 2)]],
+        ['git ls-remote --exit-code origin refs/heads/release-candidate/v1.3.0', [result('branch\n')]],
+        [
+          'gh pr list --state all --head release-candidate/v1.3.0 --base main --json state',
+          [result('[{"state":"OPEN"}]')],
+        ],
+        [
+          'gh run list --workflow prepare-release.yml --event workflow_dispatch --limit 50 --json databaseId,displayTitle',
+          [result('[]'), result('[{"databaseId":123,"displayTitle":"Prepare v1.3.0"}]')],
+        ],
+        ['gh workflow run prepare-release.yml -f version=1.3.0 -f finalize_changelog=true', [result()]],
+        ['gh run watch 123 --exit-status', [result()]],
+        [
+          'gh pr list --state all --head release-candidate/v1.3.0 --base main --json url',
+          [result('[{"url":"https://github.com/thekbb/expand-aws-iam-wildcards/pull/123"}]')],
+        ],
+      ]),
+    );
+
+    const exitCode = runReleaseCli({
+      argv: ['node', 'release.ts', '1.3.0'],
+      runtime,
+      stdout: runtime.stdout ?? console,
+      stderr: { error: (message: string) => errors.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(errors).toEqual([]);
+    expect(calls).toContain('gh workflow run prepare-release.yml -f version=1.3.0 -f finalize_changelog=true');
+    expect(output.join('\n')).toContain(
+      'Refreshing existing release preparation PR for release-candidate/v1.3.0',
+    );
   });
 
   it('rejects prepare mode when the local release tag already exists', () => {

--- a/scripts/release/orchestrator.ts
+++ b/scripts/release/orchestrator.ts
@@ -105,7 +105,12 @@ function prepareRelease(services: ReleaseServices, args: ParsedReleaseArgs): voi
   }
 
   if (git.refExistsOnOrigin(`refs/heads/${args.names.branch}`)) {
-    throw new Error(`remote release candidate branch already exists: ${args.names.branch}`);
+    const candidate = github.firstPullRequest(args.names.branch, 'state');
+    if (candidate?.state !== 'OPEN') {
+      throw new Error(`remote release candidate branch has no open pull request: ${args.names.branch}`);
+    }
+
+    runtime.stdout.log(`Refreshing existing release preparation PR for ${args.names.branch}`);
   }
 
   runtime.stdout.log(`Dispatching Prepare Release for ${args.names.tag}`);


### PR DESCRIPTION
Makes release preparation reruns refresh the existing open candidate PR while rejecting orphaned candidate branches.
Uses the pinned pull request action with an explicit release-file allowlist, read-only workflow permissions, and a 20-minute timeout.