### PR TITLE
Verify release merge commit signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exercise the compiled action lifecycle against a paginated local GitHub API fixture
 - Verify comment creation, reruns, updates, cleanup, and reply preservation in a controlled GitHub pull request
 - Make release-candidate reruns refresh the existing pull request with an explicit file allowlist
+- Require the exact release-candidate merge commit to carry an approved GitHub signature before tagging
 
 ## [1.4.0] - 2026-07-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,22 @@ Release bundles are generated on Ubuntu through GitHub Actions rather than being
 Releases originate from `main`; the `release-candidate/$TAG` branch is a temporary review branch created by the
 prepare workflow.
 
+The `main` branch ruleset must require signed commits and must not let release
+automation bypass that requirement. Merge release-candidate pull requests in
+the GitHub interface so GitHub creates the signed merge commit.
+
+Before creating a version tag, the release command resolves the candidate pull
+request's exact merge SHA and checks its GitHub signature record. The commit
+must be valid, signed by GitHub's `web-flow` signer, and use an approved GitHub
+web-flow signing key. The currently approved key ID is
+`B5690EEEBB952194`.
+
+If GitHub rotates that key, verify the new key against
+[GitHub's published web-flow key](https://github.com/web-flow.gpg) and a known
+GitHub-created merge commit before adding its ID to the allowlist in
+`scripts/release/github.ts`. Do not bypass the signature check to complete a
+release.
+
 1. Set the release variables:
 
    ```bash
@@ -241,6 +257,42 @@ prepare workflow.
    release_sha="$(gh pr view "$BRANCH" --json mergeCommit --jq '.mergeCommit.oid')"
    git fetch origin main --tags
    git merge-base --is-ancestor "$release_sha" origin/main
+   signature_query='
+   query($owner: String!, $name: String!, $oid: GitObjectID!) {
+     repository(owner: $owner, name: $name) {
+       object(oid: $oid) {
+         ... on Commit {
+           oid
+           signature {
+             isValid
+             signer { login }
+             state
+             wasSignedByGitHub
+             ... on GpgSignature { keyId }
+           }
+         }
+       }
+     }
+   }'
+   signature_filter='
+   .data.repository.object
+   | [
+       .oid,
+       .signature.isValid,
+       .signature.state,
+       .signature.wasSignedByGitHub,
+       .signature.signer.login,
+       .signature.keyId
+     ]
+   | @tsv'
+   signature_record="$(gh api graphql \
+     -f query="$signature_query" \
+     -f owner=thekbb \
+     -f name=expand-aws-iam-wildcards \
+     -f oid="$release_sha" \
+     --jq "$signature_filter")"
+   expected_signature_record="$release_sha"$'\ttrue\tVALID\ttrue\tweb-flow\tB5690EEEBB952194'
+   test "$signature_record" = "$expected_signature_record"
    git tag -s "$TAG" "$release_sha" -m "$TAG"
    git push origin "refs/tags/$TAG"
    ```

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Published releases are prepared and verified in GitHub Actions on Ubuntu.
 - **Auditable** - the TypeScript source is small and `dist/index.js` is committed
 - **No runtime dependency fetches** - IAM action data is bundled at build time and refreshed in this repo separately
 - **Linux-generated release bundles** - the `Prepare Release` workflow builds `dist/index.js` on Ubuntu before tagging
+- **Verified release commits** - version tags target the exact GitHub-signed and verified release-candidate merge SHA
 - **OIDC-backed release provenance** - the `Verify Draft Release` workflow attests the shipped action bundle before publication
 
 ```yaml

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { type CommandResult, type ReleaseRuntime } from './release/command.js';
 import { runReleaseCli } from './release.js';
 import { usage } from './release/cli.js';
+import { GITHUB_COMMIT_SIGNATURE_QUERY } from './release/github.js';
 
 function result(stdout = '', status = 0): CommandResult {
   return { status, stderr: '', stdout };
@@ -43,6 +44,22 @@ function createRuntime(responses: ReadonlyMap<string, CommandResult[]>): {
 }
 
 const releaseSha = 'babecafebabecafebabecafebabecafebabecafe';
+
+function commitSignatureCommand(sha: string): string {
+  return [
+    'gh',
+    'api',
+    'graphql',
+    '-f',
+    `query=${GITHUB_COMMIT_SIGNATURE_QUERY}`,
+    '-f',
+    'owner=thekbb',
+    '-f',
+    'name=expand-aws-iam-wildcards',
+    '-f',
+    `oid=${sha}`,
+  ].join(' ');
+}
 
 function continueResponses({
   changelog = '## [1.3.0] - 2026-07-06\n\n[1.3.0]: https://example.test/compare/v1.2.7...v1.3.0\n',
@@ -91,6 +108,26 @@ function continueResponses({
       [result(`[{"state":"MERGED","mergeCommit":{"oid":"${releaseSha}"}}]`)],
     ],
     [`git merge-base --is-ancestor ${releaseSha} origin/main`, [result()]],
+    [
+      commitSignatureCommand(releaseSha),
+      [result(JSON.stringify({
+        data: {
+          repository: {
+            object: {
+              oid: releaseSha,
+              signature: {
+                __typename: 'GpgSignature',
+                isValid: true,
+                keyId: 'B5690EEEBB952194',
+                signer: { login: 'web-flow' },
+                state: 'VALID',
+                wasSignedByGitHub: true,
+              },
+            },
+          },
+        },
+      }))],
+    ],
     [`git show ${releaseSha}:package.json`, [result(`{"version":"${packageVersion}"}`)]],
     [`git show ${releaseSha}:package-lock.json`, [result(`{"version":"${lockfileVersion}"}`)]],
     [`git show ${releaseSha}:CHANGELOG.md`, [result(changelog)]],

--- a/scripts/release/github.test.ts
+++ b/scripts/release/github.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { type CommandResult, type ReleaseRuntime } from './command.js';
+import { createGitHubClient } from './github.js';
+
+const releaseSha = 'babecafebabecafebabecafebabecafebabecafe';
+
+function result(stdout: string): CommandResult {
+  return { status: 0, stderr: '', stdout };
+}
+
+function signatureResponse(overrides: Record<string, unknown> = {}, oid = releaseSha): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        object: {
+          oid,
+          signature: {
+            __typename: 'GpgSignature',
+            isValid: true,
+            keyId: 'B5690EEEBB952194',
+            signer: { login: 'web-flow' },
+            state: 'VALID',
+            wasSignedByGitHub: true,
+            ...overrides,
+          },
+        },
+      },
+    },
+  });
+}
+
+function githubFor(response: string): ReturnType<typeof createGitHubClient> {
+  const runtime: ReleaseRuntime = {
+    env: {},
+    promptEnter: () => undefined,
+    run: () => result(response),
+    sleep: () => undefined,
+    stdinIsTTY: false,
+    stdout: console,
+  };
+  return createGitHubClient(runtime);
+}
+
+describe('release commit signature policy', () => {
+  it('accepts the exact commit signed by the approved GitHub web-flow key', () => {
+    expect(() => githubFor(signatureResponse()).assertReleaseCommitSignature(releaseSha)).not.toThrow();
+  });
+
+  it('rejects a response for a different commit', () => {
+    const wrongSha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    expect(() => githubFor(signatureResponse({}, wrongSha)).assertReleaseCommitSignature(releaseSha)).toThrow(
+      `GitHub returned the wrong release commit: ${wrongSha}, expected ${releaseSha}`,
+    );
+  });
+
+  it('rejects an unsigned commit', () => {
+    const response = JSON.stringify({ data: { repository: { object: { oid: releaseSha, signature: null } } } });
+    expect(() => githubFor(response).assertReleaseCommitSignature(releaseSha)).toThrow(
+      `release commit ${releaseSha} is unsigned`,
+    );
+  });
+
+  it('rejects a signature GitHub did not verify', () => {
+    expect(() => githubFor(signatureResponse({ isValid: false, state: 'EXPIRED_KEY' }))
+      .assertReleaseCommitSignature(releaseSha)).toThrow(
+      `release commit ${releaseSha} signature is not verified: EXPIRED_KEY`,
+    );
+  });
+
+  it('rejects a valid signature from a different signer', () => {
+    expect(() => githubFor(signatureResponse({ signer: { login: 'thekbb' } }))
+      .assertReleaseCommitSignature(releaseSha)).toThrow(
+      `release commit ${releaseSha} was not signed by GitHub web-flow`,
+    );
+  });
+
+  it('rejects an unapproved GitHub signing key', () => {
+    expect(() => githubFor(signatureResponse({ keyId: '0123456789ABCDEF' }))
+      .assertReleaseCommitSignature(releaseSha)).toThrow(
+      `release commit ${releaseSha} uses an unapproved GitHub signing key: 0123456789ABCDEF`,
+    );
+  });
+});

--- a/scripts/release/github.ts
+++ b/scripts/release/github.ts
@@ -18,7 +18,36 @@ export interface ReleaseView {
   url?: string;
 }
 
+interface CommitSignature {
+  __typename?: string;
+  isValid?: boolean;
+  keyId?: string | null;
+  signer?: { login?: string } | null;
+  state?: string;
+  wasSignedByGitHub?: boolean;
+}
+
+interface CommitSignatureResponse {
+  data?: {
+    repository?: {
+      object?: {
+        oid?: string;
+        signature?: CommitSignature | null;
+      } | null;
+    } | null;
+  };
+}
+
+const RELEASE_REPOSITORY_OWNER = 'thekbb';
+const RELEASE_REPOSITORY_NAME = 'expand-aws-iam-wildcards';
+const GITHUB_WEB_FLOW_SIGNER = 'web-flow';
+const GITHUB_WEB_FLOW_SIGNING_KEY_IDS = new Set(['B5690EEEBB952194']);
+
+export const GITHUB_COMMIT_SIGNATURE_QUERY =
+  'query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid signature{__typename isValid signer{login} state wasSignedByGitHub ... on GpgSignature{keyId}}}}}}';
+
 export interface GitHubClient {
+  assertReleaseCommitSignature: (sha: string) => void;
   authStatus: () => void;
   createDraftRelease: (tag: string) => void;
   dispatchPrepareRelease: (version: string, finalizeChangelog: boolean) => void;
@@ -45,6 +74,46 @@ function listWorkflowRuns(
 
 export function createGitHubClient(runtime: ReleaseRuntime): GitHubClient {
   return {
+    assertReleaseCommitSignature: (sha) => {
+      const response = JSON.parse(
+        runText(runtime, 'gh', [
+          'api',
+          'graphql',
+          '-f',
+          `query=${GITHUB_COMMIT_SIGNATURE_QUERY}`,
+          '-f',
+          `owner=${RELEASE_REPOSITORY_OWNER}`,
+          '-f',
+          `name=${RELEASE_REPOSITORY_NAME}`,
+          '-f',
+          `oid=${sha}`,
+        ]),
+      ) as CommitSignatureResponse;
+      const commit = response.data?.repository?.object;
+      if (commit?.oid !== sha) {
+        throw new Error(`GitHub returned the wrong release commit: ${commit?.oid ?? 'missing'}, expected ${sha}`);
+      }
+
+      const signature = commit.signature;
+      if (signature === null || signature === undefined) {
+        throw new Error(`release commit ${sha} is unsigned`);
+      }
+
+      if (signature.isValid !== true || signature.state !== 'VALID') {
+        throw new Error(`release commit ${sha} signature is not verified: ${signature.state ?? 'UNKNOWN'}`);
+      }
+
+      if (signature.wasSignedByGitHub !== true || signature.signer?.login !== GITHUB_WEB_FLOW_SIGNER) {
+        throw new Error(`release commit ${sha} was not signed by GitHub web-flow`);
+      }
+
+      if (signature.__typename !== 'GpgSignature' ||
+          signature.keyId === null ||
+          signature.keyId === undefined ||
+          !GITHUB_WEB_FLOW_SIGNING_KEY_IDS.has(signature.keyId)) {
+        throw new Error(`release commit ${sha} uses an unapproved GitHub signing key: ${signature.keyId ?? 'unknown'}`);
+      }
+    },
     authStatus: () => runChecked(runtime, 'gh', ['auth', 'status']),
     createDraftRelease: (tag) => runChecked(runtime, 'gh', ['release', 'create', tag, '--draft', '--verify-tag', '--generate-notes']),
     dispatchPrepareRelease: (version, finalizeChangelog) =>

--- a/scripts/release/orchestrator.ts
+++ b/scripts/release/orchestrator.ts
@@ -280,6 +280,7 @@ function continueRelease(services: ReleaseServices, args: ParsedReleaseArgs): vo
   }
 
   git.assertReleaseCommitOnOriginMain(releaseSha);
+  github.assertReleaseCommitSignature(releaseSha);
 
   const packageVersion = fileVersionAt(services, releaseSha, 'package.json');
   const lockfileVersion = fileVersionAt(services, releaseSha, 'package-lock.json');


### PR DESCRIPTION
Now Require the exact release-candidate merge commit to have a valid GitHub web-flow signature before creating a release tag.

Covers unsigned commits, invalid signatures, wrong SHAs, wrong signers, expired keys, and unapproved key rotations. Documents the required branch rule and key rotation process.