### PR TITLE
Recheck release commit signatures

### DIFF
--- a/.github/workflows/publish-verified-release.yml
+++ b/.github/workflows/publish-verified-release.yml
@@ -127,6 +127,8 @@ jobs:
             exit 1
           fi
 
+          bash scripts/verify-github-commit.sh "$GITHUB_REPOSITORY" "$tag_commit"
+
           expected_version="${TAG#v}"
           package_version="$(node -p "require('./package.json').version")"
           lockfile_version="$(node -p "require('./package-lock.json').version")"

--- a/.github/workflows/verify-draft-release.yml
+++ b/.github/workflows/verify-draft-release.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Verify signed release tag
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
         run: |
           git fetch --no-tags origin main:refs/remotes/origin/main
@@ -92,6 +93,8 @@ jobs:
             echo "Expected $TAG commit $tag_commit to be reachable from origin/main."
             exit 1
           fi
+
+          bash scripts/verify-github-commit.sh "$GITHUB_REPOSITORY" "$tag_commit"
 
       - name: Ensure a draft release exists for the requested tag
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,9 +326,11 @@ release.
    ```
 
    That workflow verifies the signed tag, rebuilds `dist/index.js` on Ubuntu,
-   attests the bundle, and immediately verifies that the provenance names the
-   exact repository, workflow, tag ref, and tag commit before dispatching
-   `Publish Verified Release`.
+   rechecks the tagged commit's GitHub web-flow signature, attests the bundle,
+   and immediately verifies that the provenance names the exact repository,
+   workflow, tag ref, and tag commit before dispatching `Publish Verified
+   Release`. The publish workflow independently repeats the signed commit,
+   signed tag, ancestry, metadata, draft release, and attestation checks.
 
 8. Check that the release is now published and immutable:
 

--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ gpg --show-keys --fingerprint keys/release-signing-key.asc
 
 `--tag` must be a semver release tag with a leading `v`. `--sha` must be a full 40-character commit SHA. The script
 derives the other value automatically, verifies the signed semver tag locally, confirms the tag resolves to the same
-commit, checks that GitHub has a published immutable release for that tag, verifies the GitHub artifact attestation
-for `dist/index.js` when `gh` is installed, and checks that the commit is on `main`. That release should have been
+commit, checks its GitHub web-flow signature when `gh` is installed, checks that GitHub has a published immutable
+release for that tag, verifies the GitHub artifact attestation for `dist/index.js` when `gh` is installed, and checks
+that the commit is on `main`. That release should have been
 prepared from a Linux-generated `release-candidate/vX.Y.Z` commit and published only after the
 `Verify Draft Release` workflow attested `dist/index.js`.
 

--- a/scripts/verify-github-commit.sh
+++ b/scripts/verify-github-commit.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository="${1:-}"
+sha="${2:-}"
+
+if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "Expected repository in owner/name form, got: ${repository:-missing}" >&2
+  exit 2
+fi
+
+if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Expected a full lowercase commit SHA, got: ${sha:-missing}" >&2
+  exit 2
+fi
+
+owner="${repository%%/*}"
+name="${repository#*/}"
+# shellcheck disable=SC2016 # GraphQL variables must be passed literally.
+signature_query='
+query($owner: String!, $name: String!, $oid: GitObjectID!) {
+  repository(owner: $owner, name: $name) {
+    object(oid: $oid) {
+      ... on Commit {
+        oid
+        signature {
+          __typename
+          isValid
+          signer { login }
+          state
+          wasSignedByGitHub
+          ... on GpgSignature { keyId }
+        }
+      }
+    }
+  }
+}'
+signature_filter='
+.data.repository.object
+| [
+    .oid,
+    .signature.__typename,
+    .signature.isValid,
+    .signature.state,
+    .signature.wasSignedByGitHub,
+    .signature.signer.login,
+    .signature.keyId
+  ]
+| @tsv'
+
+signature_record="$(gh api graphql \
+  -f query="$signature_query" \
+  -f owner="$owner" \
+  -f name="$name" \
+  -f oid="$sha" \
+  --jq "$signature_filter")"
+expected_record="$sha"$'\tGpgSignature\ttrue\tVALID\ttrue\tweb-flow\tB5690EEEBB952194'
+
+if [[ "$signature_record" != "$expected_record" ]]; then
+  echo "Commit $sha does not have the approved GitHub web-flow signature." >&2
+  echo "Received: ${signature_record:-missing}" >&2
+  exit 1
+fi
+
+echo "Verified GitHub web-flow signature for $sha."

--- a/scripts/verify-github-commit.test.ts
+++ b/scripts/verify-github-commit.test.ts
@@ -1,0 +1,65 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = resolve(import.meta.dirname, '..');
+const verifier = join(repositoryRoot, 'scripts/verify-github-commit.sh');
+const sha = 'babecafebabecafebabecafebabecafebabecafe';
+
+function verify(record: string, repository = 'thekbb/expand-aws-iam-wildcards', commit = sha) {
+  const fixture = mkdtempSync(join(tmpdir(), 'github-commit-verifier-'));
+  try {
+    const fakeGh = join(fixture, 'gh');
+    writeFileSync(fakeGh, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$SIGNATURE_RECORD"\n');
+    chmodSync(fakeGh, 0o755);
+
+    return spawnSync('bash', [verifier, repository, commit], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${fixture}:${process.env.PATH ?? ''}`,
+        SIGNATURE_RECORD: record,
+      },
+    });
+  } finally {
+    rmSync(fixture, { force: true, recursive: true });
+  }
+}
+
+const validRecord = [
+  sha,
+  'GpgSignature',
+  'true',
+  'VALID',
+  'true',
+  'web-flow',
+  'B5690EEEBB952194',
+].join('\t');
+
+describe('GitHub release commit verifier', () => {
+  it('accepts the exact commit signed by the approved GitHub web-flow key', () => {
+    const result = verify(validRecord);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`Verified GitHub web-flow signature for ${sha}.`);
+  });
+
+  it.each([
+    ['wrong SHA', validRecord.replace(sha, 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')],
+    ['invalid signature', validRecord.replace('\ttrue\tVALID\t', '\tfalse\tEXPIRED_KEY\t')],
+    ['wrong signer', validRecord.replace('\tweb-flow\t', '\tthekbb\t')],
+    ['unapproved key', validRecord.replace('B5690EEEBB952194', '0123456789ABCDEF')],
+  ])('rejects %s', (_label, record) => {
+    const result = verify(record);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`Commit ${sha} does not have the approved GitHub web-flow signature.`);
+  });
+
+  it('rejects malformed repository and commit arguments before calling GitHub', () => {
+    expect(verify(validRecord, 'not-a-repository').status).toBe(2);
+    expect(verify(validRecord, 'thekbb/expand-aws-iam-wildcards', 'short').status).toBe(2);
+  });
+});

--- a/verify-release.sh
+++ b/verify-release.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 REPO_URL="${REPO_URL:-https://github.com/thekbb/expand-aws-iam-wildcards.git}"
 TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 SHA_REGEX='^[0-9a-fA-F]{40}$'
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'EOF'
@@ -315,6 +316,32 @@ verify_release_attestation() {
   fi
 }
 
+verify_release_commit_signature() {
+  local signature_output=''
+
+  if [[ -z "$resolved_sha" ]]; then
+    emit_result SKIP 'Release commit signature is valid' 'release commit could not be determined'
+    return
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    emit_result SKIP 'Release commit signature is valid' 'GitHub CLI is not installed'
+    return
+  fi
+
+  if ! resolve_github_repo; then
+    emit_result SKIP 'Release commit signature is valid' 'GitHub repository could not be determined'
+    return
+  fi
+
+  if signature_output="$(bash "$SCRIPT_DIR/scripts/verify-github-commit.sh" \
+    "${github_owner}/${github_repo}" "$resolved_sha" 2>&1)"; then
+    emit_result PASS 'Release commit signature is valid' "$signature_output"
+  else
+    emit_result FAIL 'Release commit signature is valid' "$(compact_message "$signature_output")"
+  fi
+}
+
 tag=''
 sha=''
 github_host=''
@@ -477,6 +504,8 @@ if [[ -n "$resolved_sha" ]] && ((fetch_ok)); then
 else
   emit_result SKIP 'Commit is reachable from origin/main' 'commit could not be resolved'
 fi
+
+verify_release_commit_signature
 
 api_tag="$resolved_tag"
 if [[ -z "$api_tag" && -n "$requested_tag" ]]; then


### PR DESCRIPTION
Rechecks the tagged commit’s GitHub web-flow signature during verification, publication, and local release checks.
Incorect SHAs, invalid signatures, wrong signers, and unapproved keys now fail consistently before publication.