### PR TITLE
update guidance to use semver over 40 char sha (with immutable releases)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,8 +349,23 @@ release.
     ```bash
     old_major_tag="$(git ls-remote --refs --tags origin "refs/tags/$MAJOR_TAG" | awk '{print $1}')"
     git tag -s -f "$MAJOR_TAG" "$TAG^{commit}" -m "$MAJOR_TAG"
-    git push --force-with-lease="refs/tags/$MAJOR_TAG:$old_major_tag" origin "refs/tags/$MAJOR_TAG"
+    if [[ -n "$old_major_tag" ]]; then
+      git push --force-with-lease="refs/tags/$MAJOR_TAG:$old_major_tag" origin "refs/tags/$MAJOR_TAG"
+    else
+      git push origin "refs/tags/$MAJOR_TAG"
+    fi
+
+    remote_major_commit="$(git ls-remote --tags origin "refs/tags/$MAJOR_TAG^{}" | awk '{print $1}')"
+    test "$remote_major_commit" = "$release_sha"
     ```
+
+    The release command prints three consumer references. Prefer the exact
+    semantic version after verifying its release is immutable, because it
+    retains Dependabot security alerts. Use the moving major reference for
+    owned repositories that should receive compatible releases without
+    workflow-edit pull requests. Use the full release commit SHA only when
+    direct pinning is required and security advisories are monitored another
+    way.
 
 The release process is safe to resume from the latest completed checkpoint:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: thekbb/expand-aws-iam-wildcards@a328eb86c5d294a3bc93ea3c334b9f2ef669efbf # v1.2.4
+      - uses: thekbb/expand-aws-iam-wildcards@v2.0.0
 ```
 
 That is the recommended setup:
@@ -99,7 +99,7 @@ threads.
 ### Terraform Only
 
 ```yaml
-- uses: thekbb/expand-aws-iam-wildcards@a328eb86c5d294a3bc93ea3c334b9f2ef669efbf # v1.2.4
+- uses: thekbb/expand-aws-iam-wildcards@v2.0.0
   with:
     file-patterns: '**/*.tf,**/*.tf.json'
 ```
@@ -107,17 +107,30 @@ threads.
 ### CloudFormation Only
 
 ```yaml
-- uses: thekbb/expand-aws-iam-wildcards@a328eb86c5d294a3bc93ea3c334b9f2ef669efbf # v1.2.4
+- uses: thekbb/expand-aws-iam-wildcards@v2.0.0
   with:
     file-patterns: '**/*.yaml,**/*.yml,**/*.json'
 ```
 
 ## Update Strategy
 
-For security, prefer a full 40-character commit SHA over a moving tag such as `@v1`. GitHub recommends full-length
-commit SHAs as the immutable option for third-party actions in its
-[Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use). If you want automatic
-updates while still using immutable workflow references, enable Dependabot for GitHub Actions in your repository:
+Prefer an exact semantic release such as `@v2.0.0` after confirming that its
+GitHub release is immutable. Immutable releases lock the release-specific tag
+to its commit, while semantic references remain eligible for Dependabot
+security alerts and security update pull requests.
+
+Use the moving `@v2` reference in repositories you own when you want compatible
+releases without pull requests that edit the workflow file. The signed `v2` tag
+moves only after the corresponding version release is verified, published, and
+immutable.
+
+A full 40-character commit SHA remains the strongest direct pin. Use it only
+when that property outweighs GitHub's current limitation that
+[Dependabot alerts for Actions require semantic version references](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-alerts#limitations).
+SHA consumers must monitor advisories through another process.
+
+Enable Dependabot for GitHub Actions to receive reviewed version or security
+update pull requests for exact semantic references:
 
 ```yaml
 # .github/dependabot.yml
@@ -129,15 +142,16 @@ updates:
       interval: 'weekly'
 ```
 
-Dependabot updates workflow `uses:` references in `.github/workflows`, including commit SHAs for GitHub Actions. The
-trailing `# v1.2.4` comment is mainly for human review so maintainers can see which release a referenced SHA
-corresponds to. Dependabot should keep that comment aligned when it updates the SHA, but the comment is
-informational, not security-critical.
+Dependabot version updates can update workflow `uses:` references in
+`.github/workflows`. Dependabot security alerts and their security update pull
+requests require a semantic version reference for GitHub Actions; SHA-pinned
+Actions do not receive those alerts.
 
-Published GitHub releases in this repository are immutable starting with `v1.2.1`. That means a release-specific tag
-such as `@v1.2.1` cannot be retargeted on GitHub after publication. The major tag `@v1` remains intentionally movable
-so it can track the latest compatible `v1` release. For GitHub's model for combining immutable releases with movable
-major tags, see
+Published GitHub releases in this repository are immutable starting with
+`v1.2.1`. That means a release-specific tag such as `@v2.0.0` cannot be
+retargeted after publication. Major tags such as `@v2` remain intentionally
+movable so they can track the latest compatible release. For GitHub's model for
+combining immutable releases with movable major tags, see
 [Using immutable releases and tags to manage your action's releases](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/using-immutable-releases-and-tags-to-manage-your-actions-releases).
 
 ## Release Process
@@ -151,7 +165,7 @@ Published releases are prepared and verified in GitHub Actions on Ubuntu.
 1. Run the `Verify Draft Release` workflow with that tag.
 1. If verification succeeds, the workflow will generate an OIDC-backed attestation for
    `dist/index.js` and publish the draft release.
-1. After publication is confirmed immutable, move the signed major tag (for example, `v1`) to the release commit.
+1. After publication is confirmed immutable, move the signed major tag (for example, `v2`) to the release commit.
 
 ## How It Works
 
@@ -166,9 +180,8 @@ Published releases are prepared and verified in GitHub Actions on Ubuntu.
 - **Minimal permissions** - only needs `pull-requests: write`
 - **No secrets required** - uses the default `github.token`
 - **No checkout required** - the action reads PR files through the GitHub API
-- **GitHub-aligned workflow security guidance** - GitHub recommends full commit SHAs for third-party actions in its
-  [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
-- **Immutable workflow references available** - prefer a full 40-character commit SHA for production workflows
+- **Immutable semantic releases** - prefer a verified immutable release tag such as `@v2.0.0` for Dependabot security alerts
+- **Full-SHA references available** - use a full commit SHA when direct pinning outweighs Dependabot alert coverage
 - **Immutable GitHub releases from `v1.2.1` onward** - published release tags cannot be retargeted after publication
 - **Dependabot-friendly** - GitHub can still raise update PRs for SHA-based action references
 - **Auditable** - the TypeScript source is small and `dist/index.js` is committed
@@ -177,15 +190,24 @@ Published releases are prepared and verified in GitHub Actions on Ubuntu.
 - **Verified release commits** - version tags target the exact GitHub-signed and verified release-candidate merge SHA
 - **OIDC-backed release provenance** - the `Verify Draft Release` workflow attests the shipped action bundle before publication
 
+Prefer the exact semantic release after confirming it is immutable:
+
 ```yaml
-uses: thekbb/expand-aws-iam-wildcards@a328eb86c5d294a3bc93ea3c334b9f2ef669efbf # v1.2.4
+uses: thekbb/expand-aws-iam-wildcards@v2.0.0
 ```
 
-If you want an immutable GitHub-side release reference and can tolerate using a tag in `uses:`, prefer a current
-release-specific tag such as `@v1.2.4`. Use `@v1` only if you deliberately want the convenience of a moving major tag.
+Use the moving major reference for compatible automatic updates without
+workflow changes in repositories you control:
 
 ```yaml
-uses: thekbb/expand-aws-iam-wildcards@v1
+uses: thekbb/expand-aws-iam-wildcards@v2
+```
+
+Use the full release commit SHA only when direct pinning is required and
+Dependabot security alerts are covered another way:
+
+```yaml
+uses: thekbb/expand-aws-iam-wildcards@a328eb86c5d294a3bc93ea3c334b9f2ef669efbf # v1.2.4
 ```
 
 ## Verify a Release

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -636,6 +636,15 @@ describe('runReleaseCli', () => {
       'git push --force-with-lease=refs/tags/v1:babecafebabecafebabecafebabecafebabecafe origin refs/tags/v1',
     );
     expect(output.join('\n')).toContain('Release complete:');
+    expect(output.join('\n')).toContain(
+      'preferred: thekbb/expand-aws-iam-wildcards@v1.3.0',
+    );
+    expect(output.join('\n')).toContain(
+      'automatic: thekbb/expand-aws-iam-wildcards@v1',
+    );
+    expect(output.join('\n')).toContain(
+      `full SHA:  thekbb/expand-aws-iam-wildcards@${releaseSha}`,
+    );
   });
 
   it('continues a release when the version tag and immutable release already exist', () => {

--- a/scripts/release/orchestrator.ts
+++ b/scripts/release/orchestrator.ts
@@ -4,6 +4,8 @@ import { type ParsedReleaseArgs } from './cli.js';
 import { createGitClient, type GitClient } from './git.js';
 import { createGitHubClient, type GitHubClient } from './github.js';
 
+const ACTION_REPOSITORY = 'thekbb/expand-aws-iam-wildcards';
+
 export interface ReleaseServices {
   git: GitClient;
   github: GitHubClient;
@@ -310,7 +312,12 @@ Release complete:
   version:   ${args.version}
   tag:       ${args.names.tag}
   major tag: ${args.names.majorTag}
-  commit:    ${releaseSha}`);
+  commit:    ${releaseSha}
+
+Consumer references:
+  preferred: ${ACTION_REPOSITORY}@${args.names.tag}
+  automatic: ${ACTION_REPOSITORY}@${args.names.majorTag}
+  full SHA:  ${ACTION_REPOSITORY}@${releaseSha}`);
 }
 
 export function runRelease(args: ParsedReleaseArgs, services: ReleaseServices): void {


### PR DESCRIPTION
Recommends immutable semantic release tags because they retain Dependabot security alerts.

Also documents moving v2 for automatic compatible updates and full-SHA references for consumers with separate advisory monitoring. Release output prints all three choices.