### PR TITLE
Fix release workflow verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -19,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.14.0'
+          node-version: '24.19.0'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: matrix.language == 'javascript-typescript'
         with:
-          node-version: '24.14.0'
+          node-version: '24.19.0'
           cache: 'npm'
 
       - name: Install dependencies and generate IAM source modules

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.14.0'
+          node-version: '24.19.0'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/publish-verified-release.yml
+++ b/.github/workflows/publish-verified-release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: automation
     steps:
@@ -70,13 +71,27 @@ jobs:
           done
 
           run_name="$(jq -r '.name // empty' <<<"$run_json")"
+          run_title="$(jq -r '.display_title // empty' <<<"$run_json")"
+          run_path="$(jq -r '.path // empty' <<<"$run_json")"
           run_event="$(jq -r '.event // empty' <<<"$run_json")"
           run_head_branch="$(jq -r '.head_branch // empty' <<<"$run_json")"
           run_head_sha="$(jq -r '.head_sha // empty' <<<"$run_json")"
 
-          expected_run_name="Verify ${TAG}"
+          expected_run_name='Verify Draft Release'
+          expected_run_title="Verify ${TAG}"
+          expected_run_path='.github/workflows/verify-draft-release.yml'
           if [[ "$run_name" != "$expected_run_name" ]]; then
             echo "Workflow run ${VERIFIED_RUN_ID} is ${run_name:-unnamed}, not ${expected_run_name}."
+            exit 1
+          fi
+
+          if [[ "$run_title" != "$expected_run_title" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} is titled ${run_title:-untitled}, not ${expected_run_title}."
+            exit 1
+          fi
+
+          if [[ "$run_path" != "$expected_run_path" ]]; then
+            echo "Workflow run ${VERIFIED_RUN_ID} used ${run_path:-an unknown workflow}, not ${expected_run_path}."
             exit 1
           fi
 

--- a/.github/workflows/verify-draft-release.yml
+++ b/.github/workflows/verify-draft-release.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
   attestations: write
 
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: automation
     outputs:
@@ -109,7 +110,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.14.0'
+          node-version: '24.19.0'
           cache: 'npm'
 
       - name: Verify package metadata matches release tag

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       checks: write
       contents: read
@@ -31,6 +32,7 @@ jobs:
 
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Link expanded actions to the current AWS Service Authorization Reference pages and native action anchors
+- Validate the exact draft-verification workflow run before publishing a release
 
 ### Changed
 


### PR DESCRIPTION
Fixes the publish handoff to verify the workflow name, tag-specific title, and workflow path. Aligns automation on Node 24.19.0, adds bounded job timeouts, and limits draft verification to the permissions needed to create attestations.