### PR TITLE
Fix question-mark-only IAM wildcard detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Detect question-mark-only IAM action wildcards such as `sqs:?etQueueAttributes`
+
 ## [2.0.0] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Published releases are prepared and verified in GitHub Actions on Ubuntu.
 ## How It Works
 
 1. Fetches the PR diff
-1. Scans added lines for IAM wildcard patterns (`service:Action*`)
+1. Scans added lines for IAM wildcard patterns (`service:Action*` or `service:Action?`)
 1. Expands wildcards against the bundled IAM action list generated from [@cloud-copilot/iam-data](https://github.com/cloud-copilot/iam-data)
 1. Posts inline review comments with links to AWS docs
 1. Reuses or updates existing bot comments in place when the anchor still matches, to reduce comment churn

--- a/dist/index.js
+++ b/dist/index.js
@@ -36960,12 +36960,14 @@ function formatActionWithLink(action) {
 ;// CONCATENATED MODULE: ./.build/workspace/src/utils.ts
 
 
-const IAM_WILDCARD_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]*\*[a-zA-Z0-9*?]*)["']?/g;
+const IAM_ACTION_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]+)["']?/g;
 const MAX_COMMENT_BODY_LENGTH = 62_000;
 function findPotentialWildcardActions(line) {
-    return [...line.matchAll(IAM_WILDCARD_PATTERN)]
+    return [...line.matchAll(IAM_ACTION_PATTERN)]
         .map((match) => match[1]?.trim())
-        .filter((action) => action !== undefined && action !== '');
+        .filter((action) => action !== undefined
+        && action !== ''
+        && (action.includes('*') || action.includes('?')));
 }
 function groupIntoConsecutiveBlocks(matches) {
     if (matches.length === 0)

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -203,6 +203,20 @@ describe('processFiles', () => {
     expect(result.stats.actionsExpanded).toBe(1);
   });
 
+  it('processes question-mark-only wildcards and creates comments', () => {
+    const files: PullRequestFile[] = [
+      { filename: 'policy.tf', patch: makePatch(['"sqs:?etQueueAttributes"']) },
+    ];
+
+    const result = processFiles(files, [], 5);
+
+    expect(result.stats.wildcardsFound).toBe(1);
+    expect(result.stats.actionsExpanded).toBe(1);
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0]?.body).toContain('sqs:GetQueueAttributes');
+    expect(result.comments[0]?.body).toContain('sqs:SetQueueAttributes');
+  });
+
   it('filters files by patterns', () => {
     const files: PullRequestFile[] = [
       { filename: 'policy.tf', patch: makePatch(['"s3:Get*"']) },

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -32,6 +32,12 @@ describe('findPotentialWildcardActions', () => {
     expect(findPotentialWildcardActions('"s3:*"')).toEqual(['s3:*']);
   });
 
+  it('finds question-mark-only wildcard actions', () => {
+    expect(findPotentialWildcardActions('"sqs:?etQueueAttributes"')).toEqual([
+      'sqs:?etQueueAttributes',
+    ]);
+  });
+
   it('returns an empty array for non-wildcard input', () => {
     expect(findPotentialWildcardActions('"s3:GetObject"')).toEqual([]);
     expect(findPotentialWildcardActions('')).toEqual([]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,13 +2,17 @@ import type { WildcardMatch, WildcardBlock } from './types.js';
 import { LEGACY_COMMENT_HEADING, withCurrentCommentMarker } from './comment-identity.js';
 import { formatActionWithLink } from './docs.js';
 
-const IAM_WILDCARD_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]*\*[a-zA-Z0-9*?]*)["']?/g;
+const IAM_ACTION_PATTERN = /["']?([a-zA-Z0-9-]+:[a-zA-Z0-9*?]+)["']?/g;
 export const MAX_COMMENT_BODY_LENGTH = 62_000;
 
 export function findPotentialWildcardActions(line: string): string[] {
-  return [...line.matchAll(IAM_WILDCARD_PATTERN)]
+  return [...line.matchAll(IAM_ACTION_PATTERN)]
     .map((match) => match[1]?.trim())
-    .filter((action): action is string => action !== undefined && action !== '');
+    .filter((action): action is string =>
+      action !== undefined
+      && action !== ''
+      && (action.includes('*') || action.includes('?'))
+    );
 }
 
 export function groupIntoConsecutiveBlocks(matches: readonly WildcardMatch[]): WildcardBlock[] {


### PR DESCRIPTION
Fixed a bug where `?` wasn't detected as a wildcard

`"sqs:?etQueueAttributes"` wouldn't expand anything.

yet,

`"sqs:?etQueue*ttributes"` correctly expands to:

```
sqs:GetQueueAttributes
sqs:SetQueueAttributes
```