### PR TITLE
Keep pull request content on data-only paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Security
+
+- Keep pull-request content on data-only paths and escape filenames written to workflow logs
+
 ### Fixed
 
 - Detect question-mark-only IAM action wildcards such as `sqs:?etQueueAttributes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Detect question-mark-only IAM action wildcards such as `sqs:?etQueueAttributes`
 
+### Changed
+
+- Update IAM action data
+
 ## [2.0.0] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ updates:
 ## Security
 
 - The action needs only `pull-requests: write` and the default GitHub token.
-- It does not check out PR code or fetch runtime IAM data or dependencies.
+- It does not check out PR code, launch processes, or evaluate PR content as
+  code.
+- It does not fetch IAM data or dependencies at runtime.
 - `dist/index.js` is committed so the shipped JavaScript can be reviewed.
 - Release tags are GPG-signed.
 - Release bundles are rebuilt on a GitHub-hosted Ubuntu runner and receive a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,20 @@ instead of opening a public issue.
 
 We'll respond within 48 hours and work with you to understand and address the issue.
 
+## Pull Request Trust Boundary
+
+Pull-request filenames and diff text are untrusted data. The action reads them
+through the GitHub API; it does not check out the pull-request branch, invoke a
+shell or subprocess, or evaluate repository content as code. The scanner only
+recognizes IAM-like strings on added diff lines. Filenames are used for glob
+matching and GitHub review-comment locations, and are escaped before appearing
+in workflow logs.
+
+Lint rules prevent production code under `src/` from importing Node.js process
+execution or virtual-machine modules and reject string-evaluation APIs. Keep the
+action on the `pull_request` event and do not add workflow steps that interpolate
+pull-request fields into shell scripts.
+
 ## Review Comment Ownership
 
 Comment updates and deletion require both a recognized action comment shape

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,4 +14,33 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     },
   },
+  {
+    files: ['src/**/*.ts'],
+    ignores: ['src/**/*.test.ts'],
+    rules: {
+      'no-eval': 'error',
+      'no-implied-eval': 'error',
+      'no-new-func': 'error',
+      'no-restricted-imports': ['error', {
+        paths: [
+          {
+            name: 'child_process',
+            message: 'Action runtime code must treat pull-request content as data.',
+          },
+          {
+            name: 'node:child_process',
+            message: 'Action runtime code must treat pull-request content as data.',
+          },
+          {
+            name: 'node:vm',
+            message: 'Action runtime code must not evaluate pull-request content.',
+          },
+          {
+            name: 'vm',
+            message: 'Action runtime code must not evaluate pull-request content.',
+          },
+        ],
+      }],
+    },
+  },
 );

--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.54.0",
     "vitest": "~4.1.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.0": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -332,6 +332,45 @@ describe('runAction', () => {
     );
   });
 
+  it('escapes pull-request filenames before writing them to workflow logs', async () => {
+    githubMocks.context.payload = {
+      pull_request: {
+        number: 9000,
+        head: {
+          sha: 'badc0de',
+        },
+      },
+    };
+    actionMocks.processFiles.mockReturnValue({
+      comments: [{ path: 'policy.tf', line: 10, body: 'comment body' }],
+      stats: {
+        filesMatched: 1,
+        fileAnalysis: analyzedFiles(1),
+        wildcardsFound: 1,
+        blocksCreated: 1,
+        actionsExpanded: 1,
+      },
+      truncatedComments: [{
+        file: 'policy.tf\n::warning::not-a-command',
+        line: 10,
+        originalActions: ['s3:*'],
+        expandedActions: ['s3:GetObject'],
+        renderedActionsCount: 0,
+      }],
+    });
+
+    await runAction();
+
+    expect(coreMocks.info).toHaveBeenCalledWith(
+      [
+        'Full IAM expansion for policy.tf\\n::warning::not-a-command:10',
+        'Rendered 0 of 1 action(s) in the PR comment.',
+        'Wildcard patterns: s3:*',
+        '- s3:GetObject',
+      ].join('\n'),
+    );
+  });
+
   it('syncs empty comments when analyzed files contain no IAM wildcards', async () => {
     githubMocks.context.payload = {
       pull_request: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,10 @@ function getWorkflowRunUrl(owner: string, repo: string): string | undefined {
   return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
 }
 
+function escapeLogData(value: string): string {
+  return JSON.stringify(value).slice(1, -1);
+}
+
 function logTruncatedComments(
   truncatedComments: readonly TruncatedComment[],
   workflowRunUrl?: string,
@@ -35,7 +39,7 @@ function logTruncatedComments(
 
   for (const truncatedComment of truncatedComments) {
     core.info([
-      `Full IAM expansion for ${truncatedComment.file}:${truncatedComment.line}`,
+      `Full IAM expansion for ${escapeLogData(truncatedComment.file)}:${truncatedComment.line}`,
       `Rendered ${truncatedComment.renderedActionsCount} of ${truncatedComment.expandedActions.length} action(s) in the PR comment.`,
       `Wildcard patterns: ${truncatedComment.originalActions.join(', ')}`,
       ...truncatedComment.expandedActions.map((action) => `- ${action}`),


### PR DESCRIPTION
Pull request filenames and diff text are untrusted input. This change keeps that input on parsing and GitHub API paths instead of allowing it to reach process execution or code evaluation.

- escape pull-request filenames before writing them to workflow logs
- prevent action runtime code from importing Node.js process execution or VM modules
- reject `eval`, `new Function`, and implied string evaluation in runtime code
- add regression coverage for command-like text embedded in a filename
- document the pull-request trust boundary in the README and security policy

The action still reads pull-request changes through the GitHub API without checking out or executing repository code.