### PR TITLE
Remove unsupported and ill-advissed unicode wildcard normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Remove unsupported Unicode asterisk normalization so expansion follows AWS
+  IAM wildcard syntax
+
 ## [2.1.0] - 2026-09-02
 
 ### Changed

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -4,13 +4,9 @@ export function expandIamAction(
   pattern: string,
   iamActions: readonly string[] = IAM_ACTIONS,
 ): string[] {
-  const normalized = pattern
-    .trim()
-    .replace(/\u2217/g, '*')  // ∗ (unicode asterisk operator)
-    .replace(/\uFF0A/g, '*')  // ＊ (fullwidth asterisk)
-    .replace(/\u204E/g, '*'); // ⁎ (low asterisk)
+  const trimmedPattern = pattern.trim();
   // Escape regex special chars except * and ?, then convert wildcards
-  const regexPattern = normalized
+  const regexPattern = trimmedPattern
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
     .replace(/\*/g, '.*')
     .replace(/\?/g, '.');


### PR DESCRIPTION
AWS IAM supports ASCII `*` and `?` as wildcards. The Unicode asterisk doppelgangers we normalized by the expansion code are not valid IAM wildcards, and the scanner never detected them during normal action runs. So I did a dumb thing dumbly (which canceled out?)

This is the only one we need:
`*` - ordinary ASCII asterisk (`U+002A`)

These doppelgangers will not actually work:
`∗` - asterisk operator (`U+2217`)
`＊` - fullwidth asterisk (`U+FF0A`)
`⁎` - low asterisk (`U+204E`)
