### PR TITLE
Prepare v2.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [2.1.1] - 2026-09-04
+
 ### Changed
 
 - Combine release verification and publication into one workflow using
@@ -307,7 +309,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial release
 
 <!-- markdownlint-disable-next-line MD053 -->
-[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.4.0...v2.0.0
 [1.4.0]: https://github.com/thekbb/expand-aws-iam-wildcards/compare/v1.3.0...v1.4.0

--- a/dist/index.js
+++ b/dist/index.js
@@ -59150,13 +59150,9 @@ const IAM_ACTIONS = [
 ;// CONCATENATED MODULE: ./.build/workspace/src/expand.ts
 
 function expandIamAction(pattern, iamActions = IAM_ACTIONS) {
-    const normalized = pattern
-        .trim()
-        .replace(/\u2217/g, '*') // ∗ (unicode asterisk operator)
-        .replace(/\uFF0A/g, '*') // ＊ (fullwidth asterisk)
-        .replace(/\u204E/g, '*'); // ⁎ (low asterisk)
+    const trimmedPattern = pattern.trim();
     // Escape regex special chars except * and ?, then convert wildcards
-    const regexPattern = normalized
+    const regexPattern = trimmedPattern
         .replace(/[.+^${}()|[\]\\]/g, '\\$&')
         .replace(/\*/g, '.*')
         .replace(/\?/g, '.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expand-aws-iam-wildcards",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expand-aws-iam-wildcards",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expand-aws-iam-wildcards",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "packageManager": "npm@10.8.0",
   "description": "GitHub Action to expand IAM wildcard actions in PR comments",


### PR DESCRIPTION
Uses locked [`@cloud-copilot/iam-data@0.21.202608251`](https://www.npmjs.com/package/@cloud-copilot/iam-data/v/0.21.202608251) with
`21794` actions across
`455` services, generates
the release bundle on Ubuntu, and updates package metadata for
`v2.1.1`.