### PR TITLE
Remove the redundant draft release verification check

### DIFF
--- a/.github/workflows/verify-draft-release.yml
+++ b/.github/workflows/verify-draft-release.yml
@@ -83,17 +83,6 @@ jobs:
 
           bash scripts/verify-github-commit.sh "$GITHUB_REPOSITORY" "$tag_commit"
 
-      - name: Ensure a draft release exists for the requested tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag }}
-        run: |
-          is_draft="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
-          if [[ "$is_draft" != "true" ]]; then
-            echo "Expected a draft release for tag $TAG before verification."
-            exit 1
-          fi
-
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24.19.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Move draft release validation to the write-scoped publication job,
+  immediately before the release is published
+
 ## [2.1.1] - 2026-09-04
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,6 +251,11 @@ After it is merged, use `--continue`. Existing matching tags, draft releases,
 and immutable releases are recognized so the command can continue from the
 latest completed checkpoint.
 
+If completing a failed release requires a source or workflow change, do not
+move its version tag. Merge the fix and release the next patch version instead.
+The failed exact version remains unpublished, and the signed major tag stays on
+the latest successfully published release.
+
 Do not manually bypass a failed signature, ancestry, metadata, attestation, or
 immutability check. Fix the reported state and rerun the command. Never rewrite
 an exact semantic version tag or immutable release.


### PR DESCRIPTION
The `v2.1.1` release failed because the read-scoped verification job could not resolve the draft release and `gh release view` returned `release not found`.

Remove that redundant check from the verification job. The publication job already verifies that the release is still a draft immediately before publishing, using its write-scoped token.