### PR TITLE
swap json for human readable status in release output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Replace raw draft-release JSON output in the release command with a friendly status
+  and release URL
+
 ## [2.1.3] - 2026-09-04
 
 ### Fixed

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -160,7 +160,7 @@ function continueResponses({
   if (!releaseAlreadyPublished && !draftReleaseExists) {
     responses.set('gh release create v1.3.0 --draft --verify-tag --generate-notes', [result()]);
     responses.set('gh release view v1.3.0 --json isDraft,tagName,url', [
-      result('{"isDraft":true,"tagName":"v1.3.0"}'),
+      result('{"isDraft":true,"tagName":"v1.3.0","url":"https://example.test/release"}'),
     ]);
   }
 
@@ -617,6 +617,7 @@ describe('runReleaseCli', () => {
     expect(calls).toContain(
       'git push --force-with-lease=refs/tags/v1:babecafebabecafebabecafebabecafebabecafe origin refs/tags/v1',
     );
+    expect(output.join('\n')).toContain('Draft release ready: https://example.test/release');
     expect(output.join('\n')).toContain('Release complete:');
     expect(output.join('\n')).toContain(
       'preferred: thekbb/expand-aws-iam-wildcards@v1.3.0',
@@ -744,7 +745,7 @@ describe('runReleaseCli', () => {
     expect(exitCode).toBe(0);
     expect(errors).toEqual([]);
     expect(calls).not.toContain('gh release create v1.3.0 --draft --verify-tag --generate-notes');
-    expect(output.join('\n')).toContain('Draft release already exists for v1.3.0');
+    expect(output.join('\n')).toContain('Draft release already exists: https://example.test/release');
   });
 
   it('rejects an existing remote release tag that points at a different commit', () => {

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -158,9 +158,8 @@ function continueResponses({
   }
 
   if (!releaseAlreadyPublished && !draftReleaseExists) {
-    responses.set('gh release create v1.3.0 --draft --verify-tag --generate-notes', [result()]);
-    responses.set('gh release view v1.3.0 --json isDraft,tagName,url', [
-      result('{"isDraft":true,"tagName":"v1.3.0","url":"https://example.test/release"}'),
+    responses.set('gh release create v1.3.0 --draft --verify-tag --generate-notes', [
+      result('https://example.test/release\n'),
     ]);
   }
 

--- a/scripts/release/github.ts
+++ b/scripts/release/github.ts
@@ -15,7 +15,7 @@ export interface ReleaseView {
   isDraft: boolean;
   isImmutable?: boolean;
   tagName: string;
-  url?: string;
+  url: string;
 }
 
 const RELEASE_REPOSITORY = 'thekbb/expand-aws-iam-wildcards';
@@ -23,13 +23,13 @@ const RELEASE_REPOSITORY = 'thekbb/expand-aws-iam-wildcards';
 export interface GitHubClient {
   assertReleaseCommitSignature: (sha: string) => void;
   authStatus: () => void;
-  createDraftRelease: (tag: string) => void;
+  createDraftRelease: (tag: string) => string;
   dispatchPrepareRelease: (version: string, finalizeChangelog: boolean) => void;
   dispatchReleaseWorkflow: (tag: string) => void;
   firstPullRequest: (branch: string, fields: string) => PullRequestSummary | undefined;
   latestWorkflowRunId: (workflow: string, runName: string, branch?: string) => string;
   requireAvailable: () => void;
-  viewRelease: (tag: string, fields?: string) => ReleaseView | undefined;
+  viewRelease: (tag: string) => ReleaseView | undefined;
   watchRun: (runId: string) => void;
 }
 
@@ -55,7 +55,8 @@ export function createGitHubClient(runtime: ReleaseRuntime): GitHubClient {
         sha,
       ]),
     authStatus: () => runChecked(runtime, 'gh', ['auth', 'status']),
-    createDraftRelease: (tag) => runChecked(runtime, 'gh', ['release', 'create', tag, '--draft', '--verify-tag', '--generate-notes']),
+    createDraftRelease: (tag) =>
+      runText(runtime, 'gh', ['release', 'create', tag, '--draft', '--verify-tag', '--generate-notes']),
     dispatchPrepareRelease: (version, finalizeChangelog) =>
       runChecked(runtime, 'gh', [
         'workflow',
@@ -89,8 +90,8 @@ export function createGitHubClient(runtime: ReleaseRuntime): GitHubClient {
     latestWorkflowRunId: (workflow, runName, branch) =>
       String(listWorkflowRuns(runtime, workflow, branch).find((run) => run.displayTitle === runName)?.databaseId ?? ''),
     requireAvailable: () => requireCommand(runtime, 'gh'),
-    viewRelease: (tag, fields = 'isDraft,isImmutable,tagName,url') => {
-      const result = runtime.run('gh', ['release', 'view', tag, '--json', fields]);
+    viewRelease: (tag) => {
+      const result = runtime.run('gh', ['release', 'view', tag, '--json', 'isDraft,isImmutable,tagName,url']);
       if (result.status !== 0) {
         return undefined;
       }

--- a/scripts/release/orchestrator.ts
+++ b/scripts/release/orchestrator.ts
@@ -188,16 +188,15 @@ function ensureDraftRelease({ github, runtime }: ReleaseServices, args: ParsedRe
   const release = github.viewRelease(args.names.tag);
   if (release !== undefined) {
     if (release.isDraft) {
-      runtime.stdout.log(`Draft release already exists: ${release.url ?? release.tagName}`);
+      runtime.stdout.log(`Draft release already exists: ${release.url}`);
     } else {
-      runtime.stdout.log(`Release already exists: ${release.url ?? release.tagName}`);
+      runtime.stdout.log(`Release already exists: ${release.url}`);
     }
     return;
   }
 
-  github.createDraftRelease(args.names.tag);
-  const createdRelease = github.viewRelease(args.names.tag, 'isDraft,tagName,url');
-  runtime.stdout.log(`Draft release ready: ${createdRelease?.url ?? createdRelease?.tagName ?? args.names.tag}`);
+  const releaseUrl = github.createDraftRelease(args.names.tag);
+  runtime.stdout.log(`Draft release ready: ${releaseUrl}`);
 }
 
 function verifyAndPublishRelease(

--- a/scripts/release/orchestrator.ts
+++ b/scripts/release/orchestrator.ts
@@ -188,16 +188,16 @@ function ensureDraftRelease({ github, runtime }: ReleaseServices, args: ParsedRe
   const release = github.viewRelease(args.names.tag);
   if (release !== undefined) {
     if (release.isDraft) {
-      runtime.stdout.log(`Draft release already exists for ${args.names.tag}`);
+      runtime.stdout.log(`Draft release already exists: ${release.url ?? release.tagName}`);
     } else {
-      runtime.stdout.log(`Release already exists for ${args.names.tag}`);
+      runtime.stdout.log(`Release already exists: ${release.url ?? release.tagName}`);
     }
-    runtime.stdout.log(JSON.stringify(release));
     return;
   }
 
   github.createDraftRelease(args.names.tag);
-  runtime.stdout.log(JSON.stringify(github.viewRelease(args.names.tag, 'isDraft,tagName,url')));
+  const createdRelease = github.viewRelease(args.names.tag, 'isDraft,tagName,url');
+  runtime.stdout.log(`Draft release ready: ${createdRelease?.url ?? createdRelease?.tagName ?? args.names.tag}`);
 }
 
 function verifyAndPublishRelease(


### PR DESCRIPTION
THe release output had some raw json in the output in it, I removed it to delight Diorio

```
Release state:
    version:   2.1.3
    tag:       v2.1.3
    major tag: v2
    branch:    release-candidate/v2.1.3
  Press Enter after the release preparation PR is merged, or Ctrl-C to resume later with --continue.
  Continuing release for v2.1.3
  {"isDraft":true,"tagName":"v2.1.3","url":"https://github.com/thekbb/expand-aws-iam-wildcards/releases/tag/untagged-16c63cc8d6b05c3910de"}
  Dispatching Verify and Publish Release for v2.1.3
  ✓ v2.1.3 Verify and Publish Release · 33882415162
  Triggered via workflow_dispatch about 1 minute ago
```